### PR TITLE
Revert to v0 spec until Safari is no longer an issue

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 /bower_components/*
+/test/*
+/coverage/*

--- a/components/ca-dialog.js
+++ b/components/ca-dialog.js
@@ -1,6 +1,4 @@
 define(['/components/helpers/create-element.js', '/components/helpers/types.js', 'document-register-element'], (createElement, types) => {
-    // desctruture until customElements is a standard.
-    const { customElements } = window;
     /**
     * buildActions
     * @param {element} element to append the actions to.
@@ -20,10 +18,9 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         /**
         * Create a HTMLElement
         * @param {number} self - simply a hack for a polyfill to allow v1 web components.
+        * @returns {undefined} initalises the component.
         */
-        constructor(self) {
-            const dialog = super(self);
-
+        createdCallback() {
             // create dialog-content and structure
             const dialogContent = createElement(null, 'article', { class: 'ca-dialog-body' });
             createElement(dialogContent, 'h1', {}, '');
@@ -38,8 +35,8 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
             dialogContent.appendChild(buttonContainer);
 
             // attach the overlay and dialog content
-            createElement(dialog, 'div', { class: 'ca-dialog-overlay' });
-            dialog.appendChild(dialogContent);
+            createElement(this, 'div', { class: 'ca-dialog-overlay' });
+            this.appendChild(dialogContent);
 
             closeButton.addEventListener('click', this.close.bind(this), false);
             // watch for click events on the dynamic container
@@ -54,7 +51,6 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
                 });
                 this.dispatchEvent(clickEvent);
             });
-            return dialog;
         }
 
         /**
@@ -74,7 +70,9 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         */
         attributeChangedCallback(name, oldValue, newValue) {
             // no need to check old / new value - see render method.
-            this.render({ [name.toString()]: newValue });
+            if (Dialog.observedAttributes.includes(name)) {
+                this.render({ [name.toString()]: newValue });
+            }
         }
 
         /**
@@ -197,5 +195,5 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
             }
         }
     }
-    customElements.define('ca-dialog', Dialog);
+    document.registerElement('ca-dialog', Dialog);
 });

--- a/components/ca-email-confirm.js
+++ b/components/ca-email-confirm.js
@@ -1,8 +1,4 @@
 define(['/components/helpers/create-element.js', '/components/helpers/types.js', 'document-register-element'], (createElement, types) => {
-
-    // destructure until customElements is a standard
-    const { customElements } = window;
-
     /**
      * Class EmailConfirm - creates a two-input email confirmation control
      * @extends HTMLElement
@@ -10,14 +6,12 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
     class EmailConfirm extends HTMLElement {
 
         /**
-        * Constructor - called when the component is added to a page
+        * createdCallback - called when the component created, (not yet attached to the DOM).
         * @param {number} self - simply a hack for a polyfill to allow v1 web components.
+        * @returns {undefined} initalises the component.
         */
-        constructor(self) {
-
-            const emailConfirm = super(self);
-
-            emailConfirm.innerHTML = `
+        createdCallback() {
+            this.innerHTML = `
                 <div class="ctl1">
                     <label>
                         <span>${this.label1}</span>
@@ -34,20 +28,20 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
                 </div>
             `;
 
-            emailConfirm.setAttribute('show-validation', 'false');
+            this.setAttribute('show-validation', 'false');
 
-            const ctl1 = emailConfirm.querySelector('.ctl1 input');
-            const ctl2 = emailConfirm.querySelector('.ctl2 input');
+            const ctl1 = this.querySelector('.ctl1 input');
+            const ctl2 = this.querySelector('.ctl2 input');
 
             ctl1.onblur = () => {
-                emailConfirm.validate();
+                this.validate();
             };
 
             ctl2.onblur = () => {
-                emailConfirm.validate();
+                this.validate();
             };
 
-            emailConfirm.validate();
+            this.validate();
         }
 
         /**
@@ -55,7 +49,6 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         * @return {array} list of attributes that should trigger a re-render
         */
         static get observedAttributes() {
-
             return ['label1', 'placeholder1', 'label2', 'placeholder2'];
         }
 
@@ -67,9 +60,10 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         * @return {void}
         */
         attributeChangedCallback(name, oldValue, newValue) {
-
-            // no need to check old / new value - see render method.
-            this.render({ [name.toString()]: newValue });
+            if (EmailConfirm.observedAttributes.includes(name)) {
+                // no need to check old / new value - see render method.
+                this.render({ [name.toString()]: newValue });
+            }
         }
 
         /**
@@ -253,5 +247,5 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         }
     }
 
-    customElements.define('ca-email-confirm', EmailConfirm);
+    document.registerElement('ca-email-confirm', EmailConfirm);
 });

--- a/components/ca-notification-container.js
+++ b/components/ca-notification-container.js
@@ -1,7 +1,4 @@
 define(['/components/helpers/create-element.js', '/components/helpers/types.js', '/components/ca-notification.js', 'document-register-element'], (createElement, types) => {
-    // desctruture until customElements is a standard.
-    const { customElements } = window;
-
     /**
      * Class NotificationContainer for a NotificationContainer web component
      * @extends HTMLElement
@@ -10,11 +7,10 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         /**
         * Create a HTMLElement
         * @param {number} self - simply a hack for a polyfill to allow v1 web components.
+        * @returns {undefined} initalises the component.
         */
-        constructor(self) {
-            const notificationContainer = super(self);
-            notificationContainer._closeStack = [];
-            return notificationContainer;
+        createdCallback() {
+            this._closeStack = [];
         }
 
         /**
@@ -90,5 +86,5 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         }
     }
 
-    customElements.define('ca-notification-container', NotificationContainer);
+    document.registerElement('ca-notification-container', NotificationContainer);
 });

--- a/components/ca-notification.js
+++ b/components/ca-notification.js
@@ -1,7 +1,4 @@
 define(['/components/helpers/create-element.js', '/components/helpers/types.js', 'document-register-element'], (createElement, types) => {
-    // desctruture until customElements is a standard.
-    const { customElements } = window;
-
     /**
      * Class Notification for a Notification web component
      * @extends HTMLElement
@@ -10,15 +7,14 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         /**
         * Create a HTMLElement
         * @param {number} self - simply a hack for a polyfill to allow v1 web components.
+        * @returns {undefined} initalises the component.
         */
-        constructor(self) {
-            const notification = super(self);
+        createdCallback() {
             const content = createElement(null, 'section', { class: 'ca-notification-content' });
             const closeButton = createElement(null, 'a', { class: 'ca-notification-close', href: '#' }, 'X');
             closeButton.addEventListener('click', this.close.bind(this), false);
-            notification.appendChild(closeButton);
-            notification.appendChild(content);
-            return notification;
+            this.appendChild(closeButton);
+            this.appendChild(content);
         }
 
         /**
@@ -38,7 +34,9 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
         */
         attributeChangedCallback(name, oldValue, newValue) {
             // no need to check old / new value - see render method.
-            this.render({ [name.toString()]: newValue });
+            if (Notification.observedAttributes.includes(name)) {
+                this.render({ [name.toString()]: newValue });
+            }
         }
 
         /**
@@ -141,5 +139,5 @@ define(['/components/helpers/create-element.js', '/components/helpers/types.js',
 
     }
 
-    customElements.define('ca-notification', Notification);
+    document.registerElement('ca-notification', Notification);
 });

--- a/components/helpers/types.js
+++ b/components/helpers/types.js
@@ -15,7 +15,8 @@ define('types', [], () => {
      * @return {boolean} email address is valid
      */
     function isValidEmailAddress(emailAddress) {
-        const regex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        // removed unrequired escapes as according to http://eslint.org/docs/rules/no-useless-escape
+        const regex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return regex.test(emailAddress);
     }
 

--- a/index.js
+++ b/index.js
@@ -16,9 +16,7 @@ server
     .use('/bower_components', express.static(path.join(__dirname, 'bower_components')))
     .use('/examples', express.static(path.join(__dirname, 'examples')))
     .use('/components', express.static(path.join(__dirname, 'components')))
-    .get('/', (req, res) => {
-        res.sendFile(path.resolve(__dirname, 'examples', 'index.html'));
-    })
+    .get('/', (req, res) => res.sendFile(path.resolve(__dirname, 'examples', 'index.html')))
     .get('/:component', (req, res) => {
         const component = req.params.component;
         res.sendFile(path.resolve(__dirname, 'examples', `${component}.html`));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
     "start": "node index.js",
+    "postinstall": "bower install",
+    "lint": "eslint .",
     "test": "wct"
   },
   "repository": {
@@ -32,8 +34,8 @@
     "web-component-tester-istanbul": "^0.10.0"
   },
   "dependencies": {
-    "body-parser": "^1.15.2",
-    "compression": "^1.6.2",
-    "express": "^4.14.0"
+    "body-parser": "1.15.2",
+    "compression": "1.6.2",
+    "express": "4.14.0"
   }
 }


### PR DESCRIPTION
This commit removes v1 customElements and uses document.registerElement
- components/ca-dialog.js -> v1 to v0
- components/ca-email-confirm.js -> v1 to v0
- components/ca-notification-container.js -> v1 to v0
- components/ca-notification.js -> v1 to v0
- components/helpers/types.js -> removed unrequired escape
- index.js -> flat return
- package.json -> absolute versions.