### PR TITLE
CA TreeView

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@
     "amd": true,
     "browser": true
   },
+  "globals": {
+    "ajax": true,
+    "ActiveXObject": true
+  },
   "rules": {
     "import/no-amd": 0
   }

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
   ],
   "dependencies": {
     "system.js": "^0.19.39",
-    "document-register-element": "^1.2.0"
+    "document-register-element": "^1.2.0",
+    "base64": "^1.0.0"
   }
 }

--- a/components/ca-treeview.css
+++ b/components/ca-treeview.css
@@ -1,0 +1,34 @@
+/* GENERIC WEB-COMPONENT OVERRIDES */
+ca-treeview { display: inline-block; vertical-align: top; border-right: none !important; background-color: #E5E8EC; margin: 0; padding: 0.5em; position: absolute; box-sizing: border-box; width: 200px; }
+
+ca-treeview nav { color: #363636; }
+ca-treeview [rel]:before { background-size: 100% 100% !important; position: absolute; left: 0; top: 0; width: 28px; height: 28px; transition: 150ms !important; }
+ca-treeview [rel] { padding-left: 30px; }
+ca-treeview [rel="root"] > span { font-weight: bold; text-decoration: none !important; cursor: default !important; }
+ca-treeview [rel="root"]:hover:before{
+    -webkit-transform: scale(1) !important;
+    -moz-transform: scale(1) !important;
+    -ms-transform: scale(1) !important;
+    -o-transform: scale(1) !important;
+    transform: scale(1) !important;
+}
+ca-treeview [rel]:hover:before { -webkit-transform: scale(1.2); -moz-transform: scale(1.2); -ms-transform: scale(1.2); -o-transform: scale(1.2); transform: scale(1.2); }
+
+ca-treeview {
+    width: 208px;
+    height: 100%;
+    display: block;
+    border-right: 3px solid #e6e6e6;
+    margin: 6px;
+}
+ca-treeview ol { position: relative; padding-left: 0; margin: 0; }
+ca-treeview li {
+     position: relative;
+     line-height: 2.2em;
+     margin-left: 0;
+     display: block;
+}
+ca-treeview span:hover { text-decoration: underline; cursor: pointer; }
+ca-treeview [data-href] { cursor: pointer; }
+
+ca-treeview [data-selected="true"] { font-weight: bold; }

--- a/components/ca-treeview.js
+++ b/components/ca-treeview.js
@@ -1,6 +1,10 @@
-define(
-['/components/helpers/create-element.js', '/components/helpers/parent-by-attribute.js', '/components/helpers/cancel-event.js', 'document-register-element'],
-(createElement, parentByAttribute, cancelEvent) => {
+define([
+    '/components/helpers/create-element.js',
+    '/components/helpers/clear-element.js',
+    '/components/helpers/parent-by-attribute.js',
+    '/components/helpers/cancel-event.js',
+    'document-register-element'
+], (createElement, clearElement, parentByAttribute, cancelEvent) => {
     /**
      * Class TreeView for a TreeView web component
      * @extends HTMLElement
@@ -9,7 +13,6 @@ define(
         /**
          * createdCallback is called when the component is first created.
          * creates children, binds events and loads data if src is avaliable.
-         * @returns {undefined} nothing.
          */
         createdCallback() {
             this.nav = createElement(this, 'nav', {});
@@ -143,7 +146,7 @@ define(
                         // we need to go get the instance data and recall this function to trigger rendering
                         this.loadData(parent, instancesUrl);
                     } else {
-                        createElement(this.ol);
+                        clearElement(this.ol);
                         this.render(parent, data);
                     }
                 });

--- a/components/ca-treeview.js
+++ b/components/ca-treeview.js
@@ -214,7 +214,7 @@ define([
         /**
          * Event handler for component.
          * @param {event} e, event object from action.
-         * @return {undefined} no returned value.
+         * @returns {undefined}
          */
         eventDelegate(e = event) {
             let el = e.target || e.srcElement;

--- a/components/ca-treeview.js
+++ b/components/ca-treeview.js
@@ -163,15 +163,15 @@ define([
         createChild(parent, tagName, item) {
             const label = item.label || item.title || 'undefined';
             const rel = (item.rel || '').toLowerCase().replace(/(describedby|described_by):/gi, '');
+            const attributes = {};
 
             // get a list of attributes to be added to the element
-            const attributes = Object.keys(item).reduce((attributeList, key) => {
-                const list = attributeList;
+            // eslint-disable-next-line no-restricted-syntax
+            for (const key in item) {
                 if (Object.prototype.hasOwnProperty.call(item, key) && key !== 'label' && key !== 'title' && key !== 'rel') {
-                    list[`data-${key}`] = item[key] || '';
+                    attributes[`data-${key}`] = item[key] || '';
                 }
-                return list;
-            }, {});
+            }
 
             if (rel !== '') {
                 attributes.rel = rel;

--- a/components/ca-treeview.js
+++ b/components/ca-treeview.js
@@ -1,0 +1,263 @@
+define(
+['/components/helpers/create-element.js', '/components/helpers/parent-by-attribute.js', '/components/helpers/cancel-event.js', 'document-register-element'],
+(createElement, parentByAttribute, cancelEvent) => {
+    /**
+     * Class TreeView for a TreeView web component
+     * @extends HTMLElement
+     */
+    class TreeView extends HTMLElement {
+        /**
+         * createdCallback is called when the component is first created.
+         * creates children, binds events and loads data if src is avaliable.
+         * @returns {undefined} nothing.
+         */
+        createdCallback() {
+            this.nav = createElement(this, 'nav', {});
+            this.ol = createElement(this.nav, 'ol');
+            this.nav.onclick = this.eventDelegate.bind(this);
+
+            if (this.dataSrc) {
+                this.loadData();
+            }
+        }
+
+        /**
+         * Called every time an attribute is changed.
+         * @param {string} attrName, the name of the changed attribute.
+         * @param {string} oldVal, previous value associated with attribute.
+         * @param {string} newVal, current value associated with attribute.
+         * @returns {undefined} if data-src or data-root change, then trigger data fetch.
+         */
+        attributeChangedCallback(attrName, oldVal, newVal) {
+            switch (attrName) {
+                case 'data-src': {
+                    if (newVal !== '') {
+                        this.loadData();
+                    }
+                } break;
+
+                case 'data-root': {
+                    this.root = newVal;
+                } break;
+
+                default: break;
+            }
+        }
+
+        /**
+         * Gets the root attribute
+         * @returns {string} data-root attribute, default is empty.
+         */
+        get root() {
+            return this.getAttribute('data-root') || '';
+        }
+
+        /**
+         * Gets the root attribute
+         * @param {string} value, data-root attribute, default is empty.
+         */
+        set root(value = '') {
+            this.setAttribute('data-root', value);
+        }
+
+        /**
+         * Gets the data-src
+         * @returns {string} data-src attribute.
+         */
+        get dataSrc() {
+            return this.getAttribute('data-src');
+        }
+
+        /**
+         * Sets the data-src
+         * @param {string} value, sets the data-src attribute.
+         */
+        set dataSrc(value) {
+            this.setAttribute('data-src', value);
+        }
+
+        /**
+         * Get the data
+         * @returns {array} returns the data.
+         */
+        get data() {
+            return this._data || [];
+        }
+
+        /**
+         * Sets the data
+         * @param {array} value, array to set as the data, defaults to empty. Invokes render.
+         */
+        set data(value = []) {
+            this._data = value;
+            this.render();
+        }
+
+        /**
+         * Gets selected item
+         * @returns {HTMLElement} selected Item
+         */
+        get selected() {
+            return this._selected;
+        }
+
+        /**
+         * Sets the selected item.
+         * @param {HTMLElement} el current element.
+         * @returns {int} max-children.
+         */
+        set selected(el) {
+            this._selected = el;
+        }
+
+        /**
+         * Gets the max children allowed.
+         * @returns {int} max-children.
+         */
+        get maxChildren() {
+            return parseInt(this.getAttribute('data-max-children') || '0', 10);
+        }
+
+        /**
+         * Sets the max children allowed.
+         * @param {int} value number of allow childre, defaults to 0.
+         */
+        set maxChildren(value = 0) {
+            this.setAttribute('data-max-children', parseInt(value, 10));
+        }
+
+        /**
+         * Load the data via an XHR request.
+         * @param {HTMLElement} parent to render with data.
+         * @param {string} dataSrc, url to load data form.
+         * @returns {undefined} either data is loaded or render is called.
+         */
+        loadData(parent, dataSrc) {
+            const dataSource = dataSrc || this.dataSrc;
+            ajax
+                .execute({ url: dataSource, dataType: 'json' })
+                .then(data => {
+                    // if this is a schema with instance links, grab the instance url
+                    const instancesUrl = (data.$schema && data.items.links) ? (data.items.links.find(link => link.rel === 'instances') || {}).href : '';
+                    if (instancesUrl !== '') {
+                        // we need to go get the instance data and recall this function to trigger rendering
+                        this.loadData(parent, instancesUrl);
+                    } else {
+                        createElement(this.ol);
+                        this.render(parent, data);
+                    }
+                });
+        }
+
+        /**
+         * create a child within the tree view
+         * @param {HTMLElement} parent, append to this.
+         * @param {string} tagName, the html tag to create.
+         * @param {object} item, schema object.
+         * @returns {HTMLElement} the newly created list item.
+         */
+        createChild(parent, tagName, item) {
+            const label = item.label || item.title || 'undefined';
+            const rel = (item.rel || '').toLowerCase().replace(/(describedby|described_by):/gi, '');
+
+            // get a list of attributes to be added to the element
+            const attributes = Object.keys(item).reduce((attributeList, key) => {
+                const list = attributeList;
+                if (Object.prototype.hasOwnProperty.call(item, key) && key !== 'label' && key !== 'title' && key !== 'rel') {
+                    list[`data-${key}`] = item[key] || '';
+                }
+                return list;
+            }, {});
+
+            if (rel !== '') {
+                attributes.rel = rel;
+            }
+
+            const listItem = createElement(parent, tagName, attributes);
+
+            createElement(listItem, 'span', null, label);
+
+            return listItem;
+        }
+
+        /**
+         * Render the TreeView based on an element and data.
+         * @param {HTMLElement} parent, starting point of tree view render.
+         * @param {object} data that builds the tree view.
+         * @returns {undefined} renders the component but doesn't return.
+         */
+        render(parent, data) {
+            let parentElement = parent || this.ol;
+            const componentData = data || this.data;
+
+            if (this.root !== '') {
+                const li = this.createChild(parentElement, 'li', { label: this.root, rel: 'root' });
+                parentElement = createElement(li, 'ol');
+            }
+
+            if (componentData.links) {
+                for (let i = 0, l = componentData.links.length; i < l; i++) {
+                    this.createChild(parentElement, 'li', componentData.links[i]);
+                }
+            }
+
+            // TODO: use events instead of this or something neater.
+            if (this.onrendercomplete) {
+                this.onrendercomplete();
+            }
+        }
+
+        /**
+         * Event handler for component.
+         * @param {event} e, event object from action.
+         * @return {undefined} no returned value.
+         */
+        eventDelegate(e = event) {
+            let el = e.target || e.srcElement;
+
+            // resolve to LI
+            el = (el.tagName !== 'LI') ? parentByAttribute(el, 'tagName', 'LI') : el;
+
+            const dataSrc = el.getAttribute('data-href') || '';
+            const rel = el.getAttribute('rel') || '';
+
+            // ignore root clicks
+            if (rel === 'root') {
+                cancelEvent(e);
+                return;
+            }
+
+            if (dataSrc !== '') {
+                cancelEvent(e);
+
+                // clear previous selection
+                if (this.selected) {
+                    this.selected.removeAttribute('data-selected');
+                }
+
+                // select new
+                el.setAttribute('data-selected', 'true');
+
+                this.selected = el;
+
+                if (this.onclick) {
+                    const txtProp = ('textContent' in document.createElement('i')) ? 'textContent' : 'innerText';
+                    const relation = el.getAttribute('rel') || '';
+                    const title = el[txtProp] || '';
+
+                    this.onclick.call(el, dataSrc, title, relation);
+                }
+            }
+        }
+
+        /**
+         * onrendercomplete blank function, it exists so other can hook into this.
+         * TODO: Kill this ASAP.
+         * @returns {undefined} undefined
+         */
+        onrendercomplete() {
+        }
+    }
+
+    document.registerElement('ca-treeview', TreeView);
+});

--- a/components/ca-treeview.js
+++ b/components/ca-treeview.js
@@ -13,7 +13,7 @@ define([
         /**
          * createdCallback is called when the component is first created.
          * creates children, binds events and loads data if src is avaliable.
-         * @returns {undefined} nothing.
+         * @returns {undefined}
          */
         createdCallback() {
             this.nav = createElement(this, 'nav', {});
@@ -257,7 +257,7 @@ define([
         /**
          * onrendercomplete blank function, it exists so other can hook into this.
          * TODO: Kill this ASAP.
-         * @returns {undefined} undefined
+         * @returns {undefined}
          */
         onrendercomplete() {
         }

--- a/components/ca-treeview.js
+++ b/components/ca-treeview.js
@@ -13,6 +13,7 @@ define([
         /**
          * createdCallback is called when the component is first created.
          * creates children, binds events and loads data if src is avaliable.
+         * @returns {undefined} nothing.
          */
         createdCallback() {
             this.nav = createElement(this, 'nav', {});
@@ -59,8 +60,8 @@ define([
          * Gets the root attribute
          * @param {string} value, data-root attribute, default is empty.
          */
-        set root(value = '') {
-            this.setAttribute('data-root', value);
+        set root(value) {
+            this.setAttribute('data-root', value || '');
         }
 
         /**

--- a/components/helpers/ajax.js
+++ b/components/helpers/ajax.js
@@ -1,0 +1,108 @@
+// generic ajax request function
+window.ajax = function(settings) {
+    const type = settings.type || 'GET';
+    const url = settings.url;
+
+    // turns a key value pair object into a http key value pair
+    const objectToFormPost = function(kvp) {
+        const data = [];
+
+        // get data into key value collection
+        Object.keys(kvp).forEach(key => {
+            // stop prototype functions from been converted into data
+            if (Object.prototype.hasOwnProperty.call(kvp, key)) {
+                data.push(`${key}=${encodeURIComponent(kvp[key])}`);
+            }
+        });
+
+        // turn data into a string
+        return data.join('&');
+    };
+
+    return new Promise((resolve, reject) => {
+        const XHR = XMLHttpRequest || ActiveXObject;
+        const request = new XHR('MSXML2.XMLHTTP.3.0');
+        let data = settings.data || {};
+        const isFormDataPost = (data.constructor === FormData);
+        const contentType = settings.contentType || 'application/x-www-form-urlencoded';
+
+        request.open(type, url, true);
+
+        // dont add a content type when posting JS FormData data as the browser needs to add the boundry info
+        if (type.toUpperCase() !== 'GET' && !isFormDataPost) {
+            request.setRequestHeader('Content-type', contentType);
+        }
+
+        if (settings.headers) {
+            Object.keys(settings.headers).forEach(header => {
+                if (Object.prototype.hasOwnProperty.call(settings.headers, header)) {
+                    request.setRequestHeader(header, settings.headers[header]);
+                }
+            });
+        }
+
+        request.onreadystatechange = function() {
+            if (request.readyState === 4) {
+                const reqText = (request.responseText || '');
+                const isJson = reqText.isJson();
+
+                if (request.status >= 200 && request.status < 300) {
+                    if (request.responseType === 'json') {
+                        resolve(request.response);
+                    } else if (settings.dataType === 'json' && isJson) {
+                        resolve(JSON.parse(reqText));
+                    } else {
+                        resolve(reqText);
+                    }
+                } else {
+                    if (request.status === 0 && url.startsWith('data:')) {
+                        // The request failed, probably due to unhelpful CORS policy in Safari.
+                        // See related WebKit bug https://bugs.webkit.org/show_bug.cgi?id=123978
+                        // Manually process the URL instead...
+                        console.log('Falling back to manual data: URI processing...');
+                        const parsedDataUri = parseDataUri(url);
+                        if (parsedDataUri) {
+                            resolve(settings.dataType === 'json' && parsedDataUri.isJson() ? JSON.parse(parsedDataUri) : parsedDataUri);
+                            return;
+                        }
+                    }
+                    try {
+                        reject([JSON.parse(reqText), request]);
+                    } catch (e) {
+                        reject([reqText, request]);
+                    }
+                }
+            }
+        };
+
+        // TODO: Rework this function, its gettting hard to follow!
+        if (type.toUpperCase() !== 'GET' && contentType === 'application/x-www-form-urlencoded' && typeof settings.data === 'object' && !isFormDataPost) {
+            data = objectToFormPost(data);
+        } else if (typeof settings.data !== 'string' && !isFormDataPost) { // dont stringify the browsers 'FormData' object
+            // stringify objects
+            data = JSON.stringify(settings.data);
+        }
+
+        try {
+            request.send(data || '');
+        } catch (e) {
+            console.log(e);
+        }
+    });
+
+    /**
+     * Manually extract the data from the URI.
+     * @param {string} href to target
+     * @returns {string} encoded data
+     */
+    function parseDataUri(href) {
+        const commaPos = href.indexOf(',');
+        // header is of the form data:[<mediatype>][;base64]
+        const header = href.substring(0, commaPos);
+        let data = href.substring(commaPos + 1);
+        if (header.endsWith(';base64')) {
+            data = escape(window.atob(data));
+        }
+        return decodeURIComponent(data);
+    }
+};

--- a/components/helpers/cancel-event.js
+++ b/components/helpers/cancel-event.js
@@ -1,0 +1,15 @@
+define('cancel-event', [], () =>
+    function cancelEvent(e) {
+        const event = e || window.event;
+        if (event) {
+            event.returnValue = false;
+            event.cancelBubble = true;
+            if (typeof (event.preventDefault) === 'function') {
+                event.preventDefault();
+            }
+            if (typeof (event.stopPropagation) === 'function') {
+                event.stopPropagation();
+            }
+        }
+    }
+);

--- a/components/helpers/clear-element.js
+++ b/components/helpers/clear-element.js
@@ -1,0 +1,7 @@
+define('clear-element', [], () =>
+    function clearElement(el) {
+        while (el && el.firstChild) {
+            el.removeChild(el.firstChild);
+        }
+    }
+);

--- a/components/helpers/parent-by-attribute.js
+++ b/components/helpers/parent-by-attribute.js
@@ -1,0 +1,16 @@
+define('parent-by-attribute', [], () =>
+    function getParentByAttribute(el, attName, attValue) {
+        const attributeName = (attName === 'class') ? 'className' : attName;
+        const attributeValue = (attributeName === 'className') ? `(^|\\s)${attValue}(\\s|$)` : attValue;
+        let tmp = el.parentNode;
+        while (tmp !== null && tmp.tagName && tmp.tagName.toLowerCase() !== 'html') {
+            if (tmp[attributeName] === attributeValue
+                || tmp.getAttribute(attributeName) === attributeValue
+                || (attributeName === 'className' && tmp[attributeName].matches(attributeValue))) {
+                return tmp;
+            }
+            tmp = tmp.parentNode;
+        }
+        return null;
+    }
+);

--- a/components/helpers/parent-by-attribute.js
+++ b/components/helpers/parent-by-attribute.js
@@ -1,4 +1,11 @@
 define('parent-by-attribute', [], () =>
+    // TODO: replace with Element.closest() and its polyfill for IE.
+    /**
+    * Walks up the DOM from the current node and returns an element where the attribute matches the value.
+    * @param {object} el - element to indicate the DOM walking starting position
+    * @param {string} attr - attribute/property name
+    * @param {string} value - value of the attribute/property to match
+    */
     function getParentByAttribute(el, attName, attValue) {
         const attributeName = (attName === 'class') ? 'className' : attName;
         const attributeValue = (attributeName === 'className') ? `(^|\\s)${attValue}(\\s|$)` : attValue;

--- a/components/helpers/secureajax.js
+++ b/components/helpers/secureajax.js
@@ -1,0 +1,264 @@
+/**
+ * ensures user is logged in before attempting to execute an AJAX request
+ */
+const ajax = (function () {
+    let oAutTokenhUri = '';
+    const hasStorage = (typeof (Storage) !== 'undefined');
+
+    // generic ajax request function
+    let request = function (settings) {
+        const type = settings.type || 'GET';
+        const url = settings.url;
+
+        // turns a key value pair object into a http key value pair
+        const objectToFormPost = function (kvp) {
+            const data = [];
+
+            // get data into key value collection
+            Object.keys(kvp).forEach(key => {
+                // stop prototype functions from been converted into data
+                if (Object.prototype.hasOwnProperty.call(kvp, key)) {
+                    data.push(`${key}=${encodeURIComponent(kvp[key])}`);
+                }
+            });
+
+            // turn data into a string
+            return data.join('&');
+        };
+
+        return new Promise((resolve, reject) => {
+            const XHR = XMLHttpRequest || ActiveXObject;
+            let data = settings.data || {};
+            const isFormDataPost = (data.constructor === FormData);
+            const contentType = settings.contentType || 'application/x-www-form-urlencoded';
+            request = new XHR('MSXML2.XMLHTTP.3.0');
+
+            request.open(type, url, true);
+
+            // dont add a content type when posting JS FormData data as the browser needs to add the boundry info
+            if (type.toUpperCase() !== 'GET' && !isFormDataPost) {
+                request.setRequestHeader('Content-type', contentType);
+            }
+
+            if (settings.headers) {
+                Object.keys(settings.headers).forEach(header => {
+                    if (Object.prototype.hasOwnProperty.call(settings.headers, header)) {
+                        request.setRequestHeader(header, settings.headers[header]);
+                    }
+                });
+            }
+
+            request.onreadystatechange = function () {
+                if (request.readyState === 4) {
+                    const reqText = (request.responseText || '');
+                    const isJson = reqText.isJson();
+
+                    if (request.status >= 200 && request.status < 300) {
+                        if (request.responseType === 'json') {
+                            // just about to resolve the request
+                            ajax.onloadend();
+                            resolve(request.response);
+                        } else if (settings.dataType === 'json' && isJson) {
+                            // just about to resolve the request
+                            ajax.onloadend();
+                            resolve(JSON.parse(reqText));
+                        } else {
+                            // just about to resolve the request
+                            ajax.onloadend();
+                            resolve(reqText);
+                        }
+                    } else {
+                        if (request.status === 0 && url.startsWith('data:')) {
+                            // The request failed, probably due to unhelpful CORS policy in Safari.
+                            // See related WebKit bug https://bugs.webkit.org/show_bug.cgi?id=123978
+                            // Manually process the URL instead...
+                            console.log('Falling back to manual data: URI processing...');
+                            const parsedDataUri = parseDataUri(url);
+                            if (parsedDataUri) {
+                                // just about to resolve the request
+                                ajax.onloadend();
+                                resolve(settings.dataType === 'json' && parsedDataUri.isJson() ? JSON.parse(parsedDataUri) : parsedDataUri);
+                                return;
+                            }
+                        }
+                        try {
+                            // just about to reject the request
+                            ajax.onloadend();
+                            reject([JSON.parse(reqText), request]);
+                        } catch (e) {
+                            // just about to reject the request
+                            ajax.onloadend();
+                            reject([reqText, request]);
+                        }
+                    }
+                }
+            };
+
+            // TODO: Rework this function, its gettting hard to follow!
+            if (type.toUpperCase() !== 'GET' && contentType === 'application/x-www-form-urlencoded' && typeof settings.data === 'object' && !isFormDataPost) {
+                data = objectToFormPost(data);
+            } else if (typeof settings.data !== 'string' && !isFormDataPost) { // dont stringify the browsers 'FormData' object
+                // stringify objects
+                data = JSON.stringify(settings.data);
+            }
+
+            try {
+                // just about to send the request
+                ajax.onloadstart();
+                request.send(data || '');
+            } catch (e) {
+                // error so invoke the onloadend
+                ajax.onloadend();
+            }
+        });
+
+        /**
+         * Manually extract the data from the URI.
+         * @param {string} href to target
+         * @returns {string} encoded data
+         */
+        function parseDataUri(href) {
+            const commaPos = href.indexOf(',');
+            // header is of the form data:[<mediatype>][;base64]
+            const header = href.substring(0, commaPos);
+            let data = href.substring(commaPos + 1);
+            if (header.endsWith(';base64')) {
+                data = escape(window.atob(data));
+            }
+            return decodeURIComponent(data);
+        }
+    };
+
+    /**
+     * check if local Storage is avaliable and fetch webapiCredentials.
+     * @return {object} webapiCredentials
+     */
+    function getCredentials() {
+        return (hasStorage) ? sessionStorage.webapiCredentials : null;
+    }
+
+    /**
+     * [saveCredentials description]
+     * @param  {object} newCredentials, webapiCredentials to identify user
+     * @return {undefined} void, stores webapiCredentials to local storage.
+     */
+    function saveCredentials(newCredentials) {
+        if (hasStorage) {
+            sessionStorage.webapiCredentials = newCredentials;
+        }
+    }
+
+    /**
+     * Removes any webapiCredentials from storage.
+     * @return {undefined} removes webapiCredentials from storage.
+     */
+    function removeCredentials() {
+        if (hasStorage) {
+            sessionStorage.removeItem('webapiCredentials');
+        }
+    }
+
+    /**
+     * [settingsWithCredentials description]
+     * @param  {object} settings, http settings.
+     * @return {object} adjusted settings with auth token added.
+     */
+    function settingsWithCredentials(settings) {
+        const settingsPlusCredentials = settings;
+        settingsPlusCredentials.headers = settings.headers || {};
+        settingsPlusCredentials.headers.Authorization = `Bearer ${getCredentials()}`;
+        return settingsPlusCredentials;
+    }
+
+    /**
+     * Perform an AJAX call, prompting the user for a username/password if authentication fails.
+     * @param  {object} settings, ajax settings.
+     * @param  {function} loginCallback function to call after login.
+     * @return {promise} result of ajax request.
+     */
+    function wrappedAjaxRequest(settings, loginCallback) {
+        let requestSettings = settings;
+        /**
+         * Checks for 401 errors and if so, prompts the user for a username/password and restarts the ajax call
+         * @param  {Object} args, reponse and request.
+         * @return {Promise} if 401 rejects and prompts for login.
+         */
+        function loginFilter(args) {
+            const response = args[0];
+            const ajaxRequest = args[1];
+
+            if (ajaxRequest.status === 401) {
+                removeCredentials();
+
+                // get oauth link from failed request
+                if (response.links) {
+                    oAutTokenhUri = (response.links.find(link => link.rel === 'oauth2-token') || {}).href || '';
+                }
+
+                if (loginCallback) {
+                    return loginCallback()
+                        .then(usernamePassword =>
+                            // Do a request for an authentication token using the login dialog details
+                            ajax.execute({
+                                url: oAutTokenhUri,
+                                type: 'post',
+                                data: `grant_type=password&username=${encodeURIComponent(usernamePassword[0])}&password=${encodeURIComponent(usernamePassword[1])}`,
+                                dataType: 'json',
+                                headers: {
+                                    Authorization: 'Basic aHRtbDUtZXhhbXBheToxMjM0NTY='
+                                }
+                            })
+                        )
+                        .then(data => {
+                            saveCredentials(data.access_token);
+                            // Retry the original ajax request with extra authorization header and return it to the caller via the promise
+                            // settings = settingsWithCredentials(settings);
+                            // When this new AJAX call completes, resolve or reject the deferred response accordingly.
+                            return ajax.execute(settingsWithCredentials(requestSettings));
+                        })
+                        .catch(reponse => {
+                            const reponseArgs = reponse;
+                            if (reponseArgs[1].status === 400 && !getCredentials()) {
+                                reponseArgs[1].statusOverride = 401; // flag this as authentication failed
+                                return Promise.reject([
+                                    { title: 'Authentication Failed', detail: 'The username or password entered was not recognised. Please try again.' },
+                                    reponseArgs[1]]
+                                );
+                            } else if (reponseArgs[1].status === 429 && !getCredentials()) {
+                                return Promise.reject([
+                                    { title: 'Authentication Blocked', detail: 'Too many failed attempts in a short period: please wait a while and then try again.' },
+                                    reponseArgs[1]
+                                ]);
+                            } else if (reponseArgs[1].status === 401) {
+                                removeCredentials(); // No point saving crap credentials.
+                                return Promise.reject([
+                                    { title: 'Authentication Failed', detail: 'The credentials supplied do not grant authorisation to perform this operation. Please try again.' },
+                                    reponseArgs[1]
+                                ]);
+                            }
+
+                            return Promise.reject(reponseArgs);
+                        });
+                }
+            }
+
+            // Otherwise don't filter, just return the original values.
+            return Promise.reject(args);
+        }
+
+        // only add creds if the requestuest needs to be secure
+        if (getCredentials()) {
+            requestSettings = settingsWithCredentials(settings);
+        }
+
+        // if secure return a catch block to handle failed login, otherwise its just a regular request
+        return request(requestSettings).catch(loginFilter);
+    }
+
+    return {
+        execute: wrappedAjaxRequest,
+        endSession: removeCredentials,
+        onloadstart() {},
+        onloadend() {}
+    };
+}());

--- a/examples/ca-treeview.html
+++ b/examples/ca-treeview.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA NOTIFICATION CONTAINER | Web Lab Common UI</title>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+    <script src="/components/helpers/secureajax.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/ca-treeview.css">
+    <style>
+      .title { font-size: 1.3em; font-weight:bold; padding: 10px 0; padding:0.25em; }
+    </style>
+  </head>
+  <body>
+    <ca-treeview></ca-treeview>
+    <script>
+        SystemJS.import('ca-treeview.js').then(() => {
+            const dataSrc = {
+              'links': [
+                  {
+                    'rel': 'describedby:learners',
+                    'href': 'http://stable-odt-api.eu-gb.mybluemix.net/api/learner/$schema',
+                    'title': 'Learners'
+                  }, {
+                    'rel': 'describedby:learnergroups',
+                    'href': 'http://stable-odt-api.eu-gb.mybluemix.net/api/learnergroup/$schema',
+                    'title': 'Learner groups'
+                  }, {
+                    'rel': 'describedby:teachers',
+                    'href': 'http://stable-odt-api.eu-gb.mybluemix.net/api/teacher/$schema',
+                    'title': 'Teachers'
+                  }
+              ]
+            };
+            const element = document.querySelector('ca-treeview');
+            element.root = 'CA Treeview';
+            element.data = dataSrc;
+        });
+    </script>
+  </body>
+</html>

--- a/examples/ca-treeview.html
+++ b/examples/ca-treeview.html
@@ -5,6 +5,7 @@
     <title>CA TREE VIEW | Web Lab Common UI</title>
     <script src="/bower_components/system.js/dist/system.js"></script>
     <script src="/components/config/index.js"></script>
+    <script src="/bower_components/base64/base64.js"></script>
     <script src="/components/helpers/secureajax.js"></script>
     <link rel="stylesheet" type="text/css" href="/components/ca-treeview.css">
     <style>

--- a/examples/ca-treeview.html
+++ b/examples/ca-treeview.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>CA NOTIFICATION CONTAINER | Web Lab Common UI</title>
+    <title>CA TREE VIEW | Web Lab Common UI</title>
     <script src="/bower_components/system.js/dist/system.js"></script>
     <script src="/components/config/index.js"></script>
     <script src="/components/helpers/secureajax.js"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,6 +13,7 @@
       <li><a href="/ca-notification-container"></a></li>
       <li><a href="/ca-confirm-input"></a></li>
       <li><a href="/ca-context"></a></li>
+      <li><a href="/ca-treeview"></a></li>
     </ol>
   </body>
 </html>

--- a/test/ca-tree-view-test.html
+++ b/test/ca-tree-view-test.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA TREE VIEW | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <!--- TODO: GLOBAL AJAX - RESOLVE -->
+    <script src="/components/helpers/secureajax.js"></script>
+    <script src="/components/config/index.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/ca-treeview.css">
+  </head>
+  <body>
+    <test-fixture id="treeview">
+      <template>
+        <ca-treeview></ca-treeview>
+      </template>
+    </test-fixture>
+    <script>
+        suite('<ca-treeview>', () => {
+            let treeview;
+
+            setup(done => {
+                SystemJS.import('ca-treeview.js').then(() => {
+                    treeview = fixture('treeview');
+                    done();
+                });
+            });
+
+            test('should be creatable', () => {
+                // Check the element has been created with the correct tag
+                expect(treeview).to.be.defined;
+                expect(treeview.tagName).to.equal('CA-TREEVIEW');
+            });
+
+            test('should allow all attributes and properties to be get and set', () => {
+                // Check that the attributes and properties can be get & set on this element
+                expect(treeview.root).to.be.defined;
+                expect(treeview.dataSrc).to.be.defined;
+                expect(treeview.maxChildren).to.be.defined;
+                expect(treeview.maxChildren).to.be.defined;
+                expect(treeview.maxChildren).to.equal(0);
+                expect(treeview.data).to.be.defined;
+                expect(treeview.data).to.be.defined;
+            });
+
+            test('should load data and create child nodes', () => {
+                // Query the dom for the new <ca-treeview> element
+                const element = document.querySelector('ca-treeview');
+
+                // The <ca-treeview> should have one immediate child
+                expect(element.children.length).to.equal(1);
+
+                // Set up the data for the render
+                const data = {
+                    'links': [
+                        { 'rel': 'describedby:learners', 'href': 'http://stable-odt-api.eu-gb.mybluemix.net/api/learner/$schema', 'title': 'Learners' },
+                        { 'rel': 'describedby:learnergroups', 'href': 'http://stable-odt-api.eu-gb.mybluemix.net/api/learnergroup/$schema', 'title': 'Learner groups' },
+                        { 'rel': 'describedby:teachers', 'href': 'http://stable-odt-api.eu-gb.mybluemix.net/api/teacher/$schema', 'title': 'Teachers' }
+                    ]
+                };
+
+                // Expecting the following structure:
+                const html = `
+                  <ca-treeview>
+                    <nav>
+                      <ol>
+                        <li data-href="http://stable-odt-api.eu-gb.mybluemix.net/api/learner/$schema" rel="learners">
+                          <span>Learners</span>
+                        </li>
+                        <li data-href="http://stable-odt-api.eu-gb.mybluemix.net/api/learnergroup/$schema" rel="learnergroups">
+                          <span>Learner groups</span>
+                        </li>
+                        <li data-href="http://stable-odt-api.eu-gb.mybluemix.net/api/teacher/$schema" rel="teachers">
+                          <span>Teachers</span>
+                        </li>
+                      </ol>
+                    </nav>
+                  </ca-treeview>`;
+
+                // Force a render
+                element.render(element.ol, data);
+
+                // And check that the generated HTML matches
+                expect(element.outerHTML).to.equal(html.replace(/\s\s+/g, ''));
+
+                // Grab hold of the NAV element
+                expect(element.nav).to.be.defined;
+                expect(element.nav.tagName).to.equal('NAV');
+                expect(element.nav.children.length).to.equal(1);
+
+                // Grab hold of the OL element
+                expect(element.ol).to.be.defined;
+                expect(element.ol.tagName).to.equal('OL');
+                expect(element.ol.children.length).to.equal(3);
+
+                // Grab hold of the first LI element
+                let li = element.ol.children[0];
+                expect(li).to.be.defined;
+                expect(li.tagName).to.equal('LI');
+                expect(li.children.length).to.equal(1);
+                expect(li.children[0].tagName).to.equal('SPAN');
+                expect(li.children[0].innerHTML).to.equal('Learners');
+
+                li = element.ol.children[1];
+                expect(li).to.be.defined;
+                expect(li.tagName).to.equal('LI');
+                expect(li.children.length).to.equal(1);
+                expect(li.children[0].tagName).to.equal('SPAN');
+                expect(li.children[0].innerHTML).to.equal('Learner groups');
+
+                li = element.ol.children[2];
+                expect(li).to.be.defined;
+                expect(li.tagName).to.equal('LI');
+                expect(li.children.length).to.equal(1);
+                expect(li.children[0].tagName).to.equal('SPAN');
+                expect(li.children[0].innerHTML).to.equal('Teachers');
+            });
+
+            test('should call loadData when changing the dataSrc property', () => {
+                // Get hold of the element attached to the body
+                const el = document.querySelector('ca-treeview');
+
+                // Spy on the createTable method of the element
+                sinon.spy(el, 'loadData');
+
+                // At this point in time, the createTable method should not have been called
+                expect(el.loadData.callCount).to.equal(0);
+
+                // Setting the schema property should cause loadData to be invoked
+                el.dataSrc = 'http://stable-odt-api.eu-gb.mybluemix.net/api/';
+
+                // Verify
+                expect(el.loadData.callCount).to.equal(1);
+            });
+        });
+        a11ySuite('treeview');
+    </script>
+  </body>
+</html>

--- a/test/helpers/cancel-event-test.html
+++ b/test/helpers/cancel-event-test.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CANCEL EVENT | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+  </head>
+  <body>
+    <test-fixture id="cancel-event">
+      <template>
+        <div class="container"></div>
+      </template>
+    </test-fixture>
+    <script>
+        // TODO: test this helper.
+        suite('types', () => {
+            let element;
+            let cancelEvent;
+
+            setup(done => {
+                SystemJS.import('helpers/cancel-event.js').then(module => {
+                    element = fixture('cancel-event');
+                    cancelEvent = module;
+                    done();
+                });
+            });
+        });
+    </script>
+  </body>
+</html>

--- a/test/helpers/clear-element-test.html
+++ b/test/helpers/clear-element-test.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CLEAR ELEMENT | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+  </head>
+  <body>
+    <test-fixture id="clear-element">
+      <template>
+        <div class="container"></div>
+      </template>
+    </test-fixture>
+    <script>
+        // TODO: test this helper.
+        suite('clear-element', () => {
+            let element;
+            let clearElement;
+
+            setup(done => {
+                SystemJS.import('helpers/clear-element.js').then(module => {
+                    element = fixture('clear-element');
+                    clearElement = module;
+                    done();
+                });
+            });
+        });
+    </script>
+  </body>
+</html>

--- a/test/helpers/parent-by-attribute-test.html
+++ b/test/helpers/parent-by-attribute-test.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>PARENT BY ATTRIBUTE | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+  </head>
+  <body>
+    <test-fixture id="parent-by-attribute">
+      <template>
+        <div class="container"></div>
+      </template>
+    </test-fixture>
+    <script>
+        // TODO: test this helper.
+        suite('types', () => {
+            let element;
+            let parentByAttribute;
+
+            setup(done => {
+                SystemJS.import('helpers/parent-by-attribute.js').then(module => {
+                    element = fixture('parent-by-attribute');
+                    parentByAttribute = module;
+                    done();
+                });
+            });
+        });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Migrating the ca-treeview web component to the common-UI project.
This required migrating Ajax and secure Ajax, as well as other components.
Files were updated against new linting rules, and where possible, logic change was avoided

Changes:
.eslintrc -> adding ajax as global until a better solution is found.
components/ca-treeview.css -> tree-view css from old private repo
components/ca-treeview.js -> tree-view from old private repo, migrated to ES6.
components/helpers/ajax.js -> moved and cleaned a little, no AMD module yet.
components/helpers/secureajax.js -> moved and cleaned a little, no AMD module yet.
components/helpers/cancel-event.js -> migrate from old helpers.js.
components/helpers/clear-element.js -> migrated from old helpers.js.
components/helpers/parent-by-attribute.js -> migrated from old helpers.js.
examples/ca-treeview.html -> moved example, had to use promises due to AMD.
test/ca-tree-view-test.html -> migrated the old tests and refactored.
test/helpers/cancel-event-test.html -> placeholder tests with TODO.
test/helpers/clear-element-test.html -> placeholder tests with TODO.
test/helpers/parent-by-attribute-test.html -> placeholder tests with TODO.