### PR TITLE
CA CONFIRM INPUT

### DIFF
--- a/components/ca-confirm-input.css
+++ b/components/ca-confirm-input.css
@@ -1,0 +1,3 @@
+.ca-confirm-input-2 {
+    margin: 10px 0 0 0 !important;
+}

--- a/components/ca-confirm-input.js
+++ b/components/ca-confirm-input.js
@@ -1,0 +1,167 @@
+define(['/components/helpers/create-element.js', 'document-register-element'], (createElement) => {
+    /**
+     * Confirm input custom web component.
+     */
+    class ConfirmInput extends HTMLElement {
+
+        /**
+         * Called when the component is created.
+         * @returns {undefined} nada.
+         */
+        createdCallback() {
+        }
+
+        /**
+         * Called when the component is attached to the DOM
+         * @returns {undefined} nada.
+         */
+        attachedCallback() {
+            // The element has been created so now create the structure
+            const required = this.getAttribute('required') === 'required';
+            const input1Options = {
+                id: `caConfirmInput_${this.name}`,
+                value: this.value,
+                type: this.type,
+                autofocus: '',
+                class: 'ca-confirm-input-1'
+            };
+            const input2Options = {
+                id: `caConfirmInput_${this.name}_confirm`,
+                type: this.type,
+                placeholder:
+                `Please re-enter ${this.label.toLowerCase()}`,
+                class: 'ca-confirm-input-2'
+            };
+
+            this.input1 = createElement(this, 'input', input1Options);
+
+            if (this.autofocus) {
+                this.input1.autofocus = true;
+            }
+
+            this.input2 = createElement(this, 'input', input2Options, this.label);
+
+            // hook exit event
+            this.input2.onblur = this.eventDelegate.bind(this);
+            this.input2.onchange = this.eventDelegate.bind(this);
+
+            this.input1.onpaste = () => false;
+            this.input2.onpaste = () => false;
+
+            this.input1.onkeyup = () => {
+                const label = document.querySelector(`label[for="${this.getAttribute('name')}"]`);
+
+                if (required) {
+                    if (this.input1.value !== '') {
+                        label.classList.add('hide-required');
+                    } else {
+                        label.classList.remove('hide-required');
+                    }
+                }
+            };
+        }
+
+        /** @return {string} name, gets the name of the component */
+        get name() {
+            return this.getAttribute('name') || '';
+        }
+
+        /** @param {string} name, sets the name of the component */
+        set name(name) {
+            this.setAttribute('name', name || '');
+        }
+
+        /** @returns {string} ca-confirm-input.label - the label to use for the confirm text box */
+        get label() {
+            return this.getAttribute('label') || '';
+        }
+
+        /** @param {string} label - the label to use for the confirm text box */
+        set label(label) {
+            this.setAttribute('label', label || '');
+        }
+
+        /** @return {string} ca-confirm-input.type - the type of input control */
+        get type() {
+            return this.getAttribute('type') || '';
+        }
+
+        /** @param {string} type - the type of input control */
+        set type(type) {
+            this.setAttribute('type', type || '');
+        }
+
+        /** @return {string} ca-confirm-input.value - the value for this component */
+        get value() {
+            if (this.input1) {
+                if (this.input1.value === '') {
+                    return '';
+                }
+                return (this.isValid()) ? this.input1.value : 'INVALID';
+            }
+            // input1 control not yet created so get value from element property
+            return this.getAttribute('value') || '';
+        }
+
+        /** @param {string} value - the value to set */
+        set value(value) {
+            if (this.input1) {
+                this.input1.value = value || '';
+            } else {
+                // input1 control not yet created so set value into element property
+                this.setAttribute('value', value || '');
+            }
+        }
+
+        /** @returns {boolean} status of autofocus */
+        get autofocus() {
+            return this.getAttribute('autofocus') === 'true';
+        }
+
+        /** @param {string} value, sets autofocus */
+        set autofocus(value) {
+            this.setAttribute('autofocus', value);
+        }
+
+        /**
+         * Event handler for ca-confirm-input.
+         * @param {Event} e, event object.
+         * @returns {undefined} void function.
+         */
+        eventDelegate(e = event) {
+            const el = e.target || e.srcElement;
+            const type = e.type.toLowerCase();
+            const tag = el.tagName.toLowerCase();
+
+            if (tag !== 'input') {
+                return;
+            }
+
+            switch (type) {
+                case 'blur': {
+                    if (this.onblur) {
+                        this.onblur.call(this, e);
+                    }
+                } break;
+
+                case 'change': {
+                    if (this.onchange) {
+                        this.onchange.call(this, e);
+                    }
+                } break;
+
+                default: break;
+            }
+        }
+
+        /**
+         * @description checks if the confirm input is valid by checking the values of input1 and input2
+         * @returns {booleans} eval of the two values.
+         */
+        isValid() {
+            return (this.input1.value === this.input2.value);
+        }
+    }
+
+    document.registerElement('ca-confirm-input', ConfirmInput);
+});

--- a/examples/ca-confirm-input.html
+++ b/examples/ca-confirm-input.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA CONFIRM INPUT | Web Lab Common UI</title>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+    <link href="/examples/index.css" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="/components/ca-confirm-input.css">
+  </head>
+  <body>
+    <div class="ca-home">
+      <a id="home" href="/"></a>
+    </div>
+    <div class="ca-title">CA CONFIRM INPUT EXAMPLE</div>
+    <ca-confirm-input name='Name' id='id' type='text' value='Value' />
+    <script>
+        SystemJS.import('ca-confirm-input.js');
+    </script>
+  </body>
+</html>

--- a/examples/ca-dialog.html
+++ b/examples/ca-dialog.html
@@ -5,9 +5,14 @@
     <title>CA DIALOG | Web Lab Common UI</title>
     <script src="/bower_components/system.js/dist/system.js"></script>
     <script src="/components/config/index.js"></script>
+    <link href="/examples/index.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/components/ca-dialog.css">
   </head>
   <body>
+    <div class="ca-home">
+      <a id="home" href="/"></a>
+    </div>
+    <div class="ca-title">CA DIALOG EXAMPLE</div>
     <ca-dialog heading="hello" buttons="add,delete,whatever" type="error"></ca-dialog>
     <button onclick="openDialog()">Open Dialog</button>
     <script>

--- a/examples/ca-email-confirm.html
+++ b/examples/ca-email-confirm.html
@@ -9,6 +9,10 @@
         <link rel="stylesheet" type="text/css" href="/components/ca-email-confirm.css">
     </head>
     <body>
+        <div class="ca-home">
+          <a id="home" href="/"></a>
+        </div>
+        <div class="ca-title">CA EMAIL CONFIRM EXAMPLE</div>
         <ca-email-confirm placeholder1="e.g. joe@bloggs.com" placeholder2="Re-enter your email address to confirm"></ca-email-confirm>
 
         <button class="toggle-validation-messages">Toggle 'Show validation messages'</button>

--- a/examples/ca-notification-container.html
+++ b/examples/ca-notification-container.html
@@ -5,6 +5,7 @@
     <title>CA NOTIFICATION CONTAINER | Web Lab Common UI</title>
     <script src="/bower_components/system.js/dist/system.js"></script>
     <script src="/components/config/index.js"></script>
+    <link href="/examples/index.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/components/ca-notification.css">
     <link rel="stylesheet" type="text/css" href="/components/ca-notification-container.css">
     <style>
@@ -15,6 +16,10 @@
     </style>
   </head>
   <body>
+    <div class="ca-home">
+      <a id="home" href="/"></a>
+    </div>
+    <div class="ca-title">CA NOTIFICATION CONTAINER EXAMPLE</div>
     <ca-notification-container></ca-notification-container>
     <button onclick="addInfoNotification()">Open Info Notification</button>
     <button onclick="addErrorNotification()">Open Error Notification</button>

--- a/examples/index.css
+++ b/examples/index.css
@@ -1,7 +1,7 @@
 /* lite reset */
 html { height: 100%; min-height: 100%; -webkit-text-size-adjust: none; -webkit-tap-highlight-color: rgba(0,0,0,0); }
 abbr, article, aside, details, figure, footer, header, main, mark, menu, nav, output, progress, section, time { display: block }
-html, body, ul, li, p, blockquote, h1, h2, h3, h4, h5, form, fieldset, legend, div, span, img, button {
+html, body, ul, li, p, blockquote, h1, h2, h3, h4, h5, form, fieldset, legend, div, span, img {
     border: 0;
     margin: 0;
     padding: 0;

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,7 @@
       <li><a href="/ca-dialog"></a></li>
       <li><a href="/ca-email-confirm"></a></li>
       <li><a href="/ca-notification-container"></a></li>
+      <li><a href="/ca-confirm-input"></a></li>
     </ol>
   </body>
 </html>

--- a/test/ca-confirm-input-test.html
+++ b/test/ca-confirm-input-test.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA DIALOG | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/ca-confirm-input.css">
+  </head>
+  <body>
+    <test-fixture id="confirm-input">
+      <template>
+        <ca-confirm-input id="id" name="Name" type="text" label="label" value="Value"></ca-confirm-input>
+      </template>
+    </test-fixture>
+    <script>
+        suite('<ca-confirm-input>', () => {
+            let confirmInput;
+
+            setup(done => {
+                SystemJS.import('ca-confirm-input.js').then(() => {
+                    confirmInput = fixture('confirm-input');
+                    done();
+                });
+            });
+
+            test('should be creatable', () => {
+                // Check the  has been created with the correct tag
+                expect(confirmInput).to.be.defined;
+                expect(confirmInput.tagName).to.equal('CA-CONFIRM-INPUT');
+            });
+
+            test('should allow all attributes and properties to be get and set', () => {
+                expect(confirmInput.name).to.be.defined;
+                expect(confirmInput.label).to.be.defined;
+                expect(confirmInput.type).to.be.defined;
+                expect(confirmInput.autofocus).to.be.defined;
+                expect(confirmInput.autofocus).to.equal(false);
+            });
+
+            test('should create the relevant structure', (done) => {
+                setTimeout(() => {
+                    const input2 = confirmInput.querySelector('ca-confirm-input .ca-confirm-input-2');
+                    expect(input2).to.be.defined;
+                    expect(input2.tagName).to.equal('INPUT');
+                    expect(input2.type).to.equal(confirmInput.type);
+                    debugger;
+                    expect(input2.id).to.equal('caConfirmInput_Name_confirm');
+                    expect(input2.className).to.equal(`ca-confirm-input-2`);
+
+                    // Make sure the confirm value is the same as the main value (otherwise confirmInput.value doesn't work)
+                    input2.value = 'Value';
+
+                    const input1 = confirmInput.querySelector('ca-confirm-input .ca-confirm-input-1');
+                    expect(input1).to.be.defined;
+                    expect(input1.tagName).to.equal('INPUT');
+                    expect(input1.type).to.equal(confirmInput.type);
+                    expect(input1.value).to.equal(confirmInput.value);
+                    expect(input1.id).to.equal('caConfirmInput_Name');
+                    expect(input1.className).to.equal('ca-confirm-input-1');
+
+                    done();
+                }, 0);
+            });
+        });
+        a11ySuite('confirm-input');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Migrating ca-confirm-input from old repo.

components/ca-confirm-input.css -> migrated
components/ca-confirm-input.js -> migrated + es6 class and amd module
examples/ca-dialog.html -> updating css and back button
examples/ca-email-confirm.html -> updating css and back button
examples/ca-notification-container.html -> updating css and back button
examples/index.css -> removing button from css reset.
test/ca-confirm-input-test.html -> migrated and fixed tests