### PR TITLE
CA File Input

### DIFF
--- a/components/ca-file-input.css
+++ b/components/ca-file-input.css
@@ -1,0 +1,33 @@
+ca-file-input input {
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+    background-color: #002c77;
+    color: #ffffff;
+    border-radius: 2px;
+}
+
+ca-file-input label {
+    display: block;
+    width: 100%!important;
+    text-shadow: none;
+    position: relative;
+    background: #fff;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    line-height: 1;
+    padding: 8px 2px 6px 6px;
+    color: #555;
+    height: 34px;
+    margin-top: 0;
+}
+
+/* Invalid file upload dialog style */
+div.dialog-file-upload li
+{
+    list-style: initial;
+    margin-left: 32px;
+}

--- a/components/ca-file-input.js
+++ b/components/ca-file-input.js
@@ -1,0 +1,253 @@
+define(['/components/helpers/create-element.js', '/components/helpers/dialogs.js', 'document-register-element'], (createElement, dialogs) => {
+    const mimeTypeToExtension = {
+        'application/pdf': { accept: '.pdf', label: 'PDF' },
+        'image/png': { accept: '.png', label: 'PNG' },
+        'image/jpeg': { accept: '.jpg,.jpeg', label: 'JPG' },
+        'image/gif': { accept: '.gif', label: 'GIF' },
+        'application/msword': { accept: '.doc,.dot', label: 'DOC' },
+        'application/vnd.ms-excel': { accept: '.xls,.xlm,.xla,.xlc,.xlt,.xlw', label: 'XLS' }
+    };
+
+    const txtProp = ('textContent' in document.createElement('i')) ? 'textContent' : 'innerText';
+
+    /**
+     * FileInput class, creates instance of ca-file-input web component
+     */
+    class FileInput extends HTMLElement {
+        /**
+         * Called when the component is created (yet to be attached to the DOM).
+         * @returns {undefined} void fuction that scaffolds based structure and binds events.
+         */
+        createdCallback() {
+            const self = this;
+            const options = {
+                type: 'file'
+            };
+
+            if (this.getAttribute('multiple')) {
+                options.multiple = true;
+            }
+
+            this.input = createElement(this, 'input', options);
+            this.label = createElement(this, 'label', { tabIndex: 0 }, this.getLabelText(this.mediaType));
+
+            this.input.addEventListener('change', function(e) {
+                const fileReaders = [];
+                const maxLen = self.maxLength;
+                const mediaType = self.mediatype;
+                let validSelectedFiles = 0;
+                const selectedFiles = this.files.length;
+                let fileLabel = '';
+                let mType;
+
+                // only if a new file(s) has been uploaded
+                if (selectedFiles > 0) {
+                    // do we need to wipe the array and reset the label
+                    self._filesAsBase64 = [];
+                    self.label[txtProp] = self.getLabelText(mediaType);
+                }
+
+                for (let i = 0; i < selectedFiles; i++) {
+                    // if the file size is within limits (or don't care what size) AND the file type is correct (or we don't care)
+                    if ((maxLen === 0 || this.files[i].size < maxLen) && (this.files[i].type === mediaType || mediaType === '')) {
+                        validSelectedFiles++;
+                        fileReaders[i] = new FileReader();
+
+                        // eslint-disable-next-line no-loop-func
+                        fileReaders[i].addEventListener('loadend', () => {
+                            if (this.readyState === 2) {
+                                // this.result contains something like "data:image/png;base64,......." so
+                                // split on ';' and ':' to get the actual media type of the uploaded file
+                                mType = this.result.split(';')[0].split(':')[1];
+
+                                // verify that the media type of the uploaded file matches the allowed upload media type
+                                if (mType === mediaType || mediaType === '') {
+                                    // TODO: in case you want to add the filename to the return result
+                                    // var temp = "name:" + this.name + ";" + this.result;
+                                    self._filesAsBase64.push(this.result);
+                                } else {
+                                    // inform the user that the selected file cannot be uploaded
+                                    dialogs.alert(self.invalidFile(mType, mediaType, this.size, maxLen), `File Upload of ${this.name}`, ['Ok'], () => {}, 'dialog-file-upload');
+
+                                    // clear the input value so if they select the same file again, it triggers a change
+                                    self.input.value = '';
+                                }
+                            }
+                        }, false);
+
+                        if (this.files[i]) {
+                            // save the name and size of the file in the fileReader object
+                            fileReaders[i].name = this.files[i].name;
+                            fileReaders[i].size = this.files[i].size;
+
+                            // then kick off the reading of the file
+                            fileReaders[i].readAsDataURL(this.files[i]);
+                        }
+
+                        // determine the label to put on the file input button
+                        fileLabel = (selectedFiles > 1) ? (`${validSelectedFiles} files selected`) : e.target.value.split('\\').pop();
+                        self.label[txtProp] = fileLabel || self.getLabelText(mediaType);
+                    } else {
+                        // inform the user that the selected file cannot be uploaded
+                        dialogs.alert(
+                            self.invalidFile(this.files[i].type, mediaType, this.files[i].size, maxLen),
+                            `File Upload of ${this.files[i].name}`,
+                            ['Ok'],
+                            () => {}, 'dialog-file-upload'
+                        );
+
+                        // clear the input value so if they select the same file again, it triggers a change
+                        self.input.value = '';
+                    }
+                }
+            });
+
+            this.label.onclick = () => {
+                this.input.click();
+                return false;
+            };
+        }
+
+        /** @property {string} ca-file-input.title - the title for the control */
+        get title() {
+            return this.getAttribute('title');
+        }
+
+        /** @param {string} title - sets the title for the control */
+        set title(title) {
+            this.setAttribute('title', title);
+            this.button[txtProp] = title;
+        }
+
+        /** @property {string} ca-file-input.id - the id for the control */
+        get id() {
+            return this.getAttribute('id');
+        }
+
+        /** @param {string} id - sets id for the control */
+        set id (id) {
+            this.setAttribute('id', id);
+        }
+
+        /** @property {string} ca-file-input.value - the value behind the component */
+        get value() {
+            return Array.isArray(this._filesAsBase64) ? this._filesAsBase64.join(', ') : this._filesAsBase64;
+        }
+
+        /** @param {string} value - sets the value behind the component */
+        set value(value) {
+            // cannot set input's value as you will get a DOMException, so if this is attempted just clear the input's filename
+            this.input.value = '';
+
+            if (value !== '') {
+                console.log("WARNING: You shouldn't be attempting to set file input 'value' - this will throw a DOMException");
+            }
+        }
+
+        /** @property {string} ca-file-input.readonly - flag to indicate whether the control is disabled */
+        get readonly() {
+            return this.getAttribute('readonly') === 'true';
+        }
+
+        /** @param {string} value - sets flag readonly to indicate whether the control is disabled */
+        set readonly(value) {
+            this.setAttribute('readonly', value);
+        }
+
+        /** @property {string} ca-file-input.mediaType - indicate accepted file types by mimetype */
+        get mediatype() {
+            return this.mediaType;
+        }
+
+        /** @param {string} value - sets the indicate accepted file types by mimetype */
+        set mediatype(value) {
+            this.mediaType = value;
+
+            // set the file extension restriction if present
+            if (this.mediaType.length > 0) {
+
+                if (mimeTypeToExtension[this.mediaType]) {
+                    this.input.setAttribute('accept', mimeTypeToExtension[this.mediaType].accept);
+                    this.label[txtProp] = this.getLabelText(this.mediaType);
+                }
+            }
+        }
+        /** @property {string} ca-file-input.multiple - indicate allow multiple file selection */
+        get multiple() {
+            return this.input.getAttribute('multiple');
+        }
+
+        /** @param {string} value - sets the attribute to allow multiple file selection */
+        set multiple(value) {
+            this.input.setAttribute('multiple', value);
+        }
+
+        /** @property {integer} ca-file-input.maxLength - maximum file size (in bytes) */
+        get maxLength() {
+            return this._maxLength || 0;
+        }
+
+        /** @param {integer} value - sets the maximum file size (in bytes) */
+        set maxLength(value) {
+            this._maxLength = value;
+        }
+
+        /**
+         * Gets the test for a mediaType by looking up the key on a private object.
+         * @param {string} mediaType, key to look up label
+         * @returns {string} the text label for a key.
+         */
+        getLabelText(mediaType) {
+            let ret = 'Choose a file';
+
+            if (mimeTypeToExtension[mediaType]) {
+                ret = `Choose a ${mimeTypeToExtension[mediaType].label} file`;
+            }
+
+            return ret;
+        }
+
+        /**
+         * Returns a valid error message for a particular media type
+         * @param {string} mediaType, the media type.
+         * @param {string} allowedMediaType, allowed types.
+         * @param {integer} fileSize, current file size.
+         * @param  {integer} maxFileSize, max file size allowed,
+         * @returns {string} associated error message.
+         */
+        invalidFile(mediaType, allowedMediaType, fileSize, maxFileSize) {
+            // the file cannot be uploaded - need to determine why
+            let ret = 'The selected file cannot be uploaded:<br/><ul>';
+
+            // the media types don't match so tell the user what file extensions are allowed
+            if (mediaType.toLowerCase() !== allowedMediaType.toLowerCase()) {
+                ret = `${ret} <br/> <li>the file must have an extension of ${mimeTypeToExtension[allowedMediaType].accept}</li>`;
+            }
+
+            // the file is too large so tell the user how big the file is and what the maximum file size is
+            if (fileSize > maxFileSize) {
+                ret = `${ret} <br/> <li>the file size is ${this.getFileSize(fileSize, 1)} and exceeds the maximum size of ${this.getFileSize(maxFileSize)}</li>`;
+            }
+
+            return `${ret} </ul><br/>`;
+        }
+
+        /**
+         * Gets the file of a file
+         * @param {integer} bytes, number of bytes.
+         * @param {integer} decimals, number of decimals.
+         * @param {integer} binaryUnits, number of binaryUnits
+         * @returns {string} friendly size.
+         */
+        getFileSize(bytes, decimals, binaryUnits) {
+            if (bytes === 0) {
+                return '0 Bytes';
+            }
+            const unitMultiple = (binaryUnits) ? 1024 : 1000;
+            const unitNames = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+            const unitChanges = Math.floor(Math.log(bytes) / Math.log(unitMultiple));
+            return `${parseFloat((bytes / Math.pow(unitMultiple, unitChanges)).toFixed(decimals || 0))}  ${unitNames[unitChanges]}`;
+        }
+    }
+    document.registerElement('ca-file-input', FileInput);
+});

--- a/components/helpers/add-class.js
+++ b/components/helpers/add-class.js
@@ -1,0 +1,8 @@
+define('add-class', ['/components/helpers/has-class.js'], (hasClass) =>
+    function (el, cls) {
+        if (!hasClass(el, cls)) {
+            // eslint-disable-next-line no-param-reassign
+            el.className += ` ${cls}`;
+        }
+    }
+);

--- a/components/helpers/add-event.js
+++ b/components/helpers/add-event.js
@@ -1,0 +1,9 @@
+define('add-event', [], () =>
+    function (el, type, func) {
+        if (el.addEventListener) {
+            el.addEventListener(type, func, false);
+        } else if (el.attachEvent) {
+            el.attachEvent(`on${type}`, func);
+        }
+    }
+);

--- a/components/helpers/dialogs.css
+++ b/components/helpers/dialogs.css
@@ -1,0 +1,245 @@
+body.no-scroll { overflow: hidden; }
+
+/* DIALOGS - generic */
+.dialog-mask {
+    background-color: rgba(48, 51, 57, 0.6);
+    background-image: url('../img/loading-anim.svg');
+    background-repeat: no-repeat;
+    background-position: center 40%;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    z-index: 999999;
+    overflow: auto; /*  overflow-x: hidden; overflow-y: scroll; */
+    overflow-x: hidden;
+}
+
+.dialog-mask[data-dialog-visible="true"]{
+    background-image: none !important;
+}
+
+.dialog {
+    background: #fff;
+    overflow: hidden;
+    padding: 0;
+    display: block;
+    z-index: 999;
+    border-radius: 6px;
+    margin: 5% auto;
+    -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
+    box-shadow: 0 3px 9px rgba(0, 0, 0, .5);
+    -webkit-animation-fill-mode: none !important;
+}
+
+.dialog.fullscreen {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto !important;
+    height: auto !important;
+    margin: 0 !important
+}
+
+.dialog .dialog-title {
+    margin: 0;
+    color: #000;
+    background: #fff !important;
+    text-indent: 18px;
+    width: auto;
+    line-height: 3em;
+    font-size: 1.2em;
+    border-bottom: 1px solid #ccc;
+}
+
+.dialog .dialog-intro {
+    background: #e4e4e4;
+    padding: 10px 20px;
+}
+.dialog-intro:before {
+    content: "i";
+    display: inline-block;
+    padding: 0px 4px;
+    border: 3px solid rgba(125,125,125,0.5);
+    border-radius: 100px;
+    margin-right: 7px;
+    font-weight: 700;
+    font-size: 16px;
+    font-family: monospace;
+    color: rgba(125,125,125,0.5);
+}
+
+
+.dialog .dialog-close {
+    color: #666;
+    cursor: pointer;
+    top: 12px;
+    right: 16px;
+    overflow: hidden;
+    position: absolute;
+    text-align: center;
+    font-weight: 700;
+    font-size: 20px;
+    z-index: 1000;
+}
+
+.dialog .dialog-close:hover {
+    color: #000;
+}
+
+.dialog .dialog-body {
+}
+
+.dialog .loading-message {
+    display: none;
+    z-index: 10;
+    width: 200px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: 0 0 0 -100px;
+    text-align: center;
+    font: bold 12px/20px 'Helvetica Neue', 'Helvetica', arial, sans-serif;
+    color: #333
+}
+
+.dialog iframe {
+    visibility: visible;
+    background: #fff;
+    height: 100%;
+    width: 100%;
+    border: 0;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    overflow: hidden
+}
+
+.dialog-no-title .dialog-body {
+    top: 12px;
+}
+
+.dialog-no-title .close {
+    top: 2px
+}
+
+.dialog-offscreen {
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: -9999em !important;
+}
+
+.dialog .dialog-buttons {
+    text-align: right;
+    background: #eee;
+    padding: 1em;
+    border-top: 1px solid #ccc;
+}
+
+.dialog .dialog-buttons .dialog-button {
+    background: #007f86;
+    color: #fff;
+    border: 0;
+    padding: 0.5em 2em;
+    border-radius: 0.5em;
+    font-size: 1em;
+    margin: 0 6px;
+    text-decoration: none;
+    -webkit-box-shadow: 1px 1px 6px #aaa;
+    -moz-box-shadow: 1px 1px 6px #aaa;
+    box-shadow: 1px 1px 6px #aaa;
+    position: relative;
+    display: inline-block;
+}
+
+.dialog .dialog-buttons .dialog-button:active {
+    top: +1px;
+    left: +1px;
+}
+
+.dialog-loading {
+    cursor: wait;
+}
+
+.dialog-loading .dialog-body {
+}
+
+.dialog-loading .loading-message {
+    display: block
+}
+
+.dialog-loading iframe {
+    position: absolute;
+    margin-left: -99999px
+}
+
+.dialog-alert .dialog-body {
+    background: #fff !important;
+    padding: 12px;
+    min-height: 60px;
+}
+
+.dialog-alert .dialog-buttons {
+}
+
+.dialog-alert .close {
+    display: none !important;
+}
+
+.dialog-confirm {
+    width: 300px;
+}
+
+.dialog-confirm .dialog-body {
+    background: #fff !important;
+    padding: 12px;
+}
+
+.dialog-confirm .close {
+    display: none !important;
+}
+
+.dialog-with-border {
+    -webkit-box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    -moz-box-shadow: 0 4px 16px rgba(0, 0, 0, .2);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    background: #FFF;
+    background-clip: padding-box;
+    border: 1px solid #ACACAC;
+    border: 1px solid rgba(0, 0, 0, 0.333);
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    -ms-border-radius: 4px;
+    -o-border-radius: 4px;
+    border-radius: 4px;
+}
+
+.dialog-scrollable {
+    overflow: auto;
+}
+
+.dialog-scrollable .dialog-body {
+    position: absolute;
+    top: 30px;
+    left: 50%;
+    width: 734px;
+    margin: 0 0 0 -367px;
+}
+
+.dialog-scrollable .close {
+    position: absolute;
+    top: 35px;
+    left: 50%;
+    margin-left: 318px
+}
+
+.dialog ul  {
+    padding-left: 16px;
+}
+.dialog li {
+    list-style: disc !important;
+}

--- a/components/helpers/dialogs.js
+++ b/components/helpers/dialogs.js
@@ -1,0 +1,524 @@
+
+define([
+    '/components/helpers/create-element.js',
+    '/components/helpers/parent-by-attribute.js',
+    '/components/helpers/cancel-event.js',
+    '/components/helpers/add-event.js',
+    '/components/helpers/has-class.js',
+    '/components/helpers/add-class.js',
+    '/components/helpers/remove-class.js',
+    '/components/helpers/clear-element.js'
+], (createElement, parentByAttribute, cancelEvent, addEvent, hasClass, addClass, removeClass, clearElement) => {
+    const dialogs = {
+        // is the object ready for interaction ?
+        ready: false,
+
+        // items will contain a list of all open dialogs
+        items: [],
+
+        // configurable loading message, placeholder will be replace with either link title or inner text
+        loadingMessage: 'Loading {0}, please wait...',
+
+        // should the script override window.open calls?
+        overrideDefaultWindows: true,
+
+        events: {
+            onbeforeopen(url, title) {
+                return true;
+            },
+            onshow(dlg) {}
+        },
+
+        init() {
+
+            if (/interactive|loaded|complete/i.test(document.readyState)) {
+
+                // assign application wide event handler
+                //  - if we have a top then use that as it ensures only one window is responsible for all dialogs, makes them stackable no matter how deep they open
+                addEvent(document, 'click', window.top.dialogs._.eventDelegate || dialogs._.eventDelegate);
+
+                // override window.open if required (if no name provided need to create a temp in order to close!!)
+                if (dialogs.overrideDefaultWindows) {
+                    window.open = dialogs.open;
+                    window.alert = dialogs.alert;
+                    window.confirm = dialogs.confirm;
+                }
+
+                dialogs.ready = true;
+            }
+
+            return dialogs.ready;
+        },
+
+        // returns a dialog object where name matches
+        get(id) {
+            return dialogs.items.where('id', id, true);
+        },
+
+        // closes a dialog where the name matches
+        close(id) {
+            const dlg = dialogs.get(id);
+
+            if (dlg) {
+                // close the dialog
+                dlg.close();
+            }
+        },
+
+        closeAll() {
+            let len = dialogs.items.length;
+
+            while (len--) {
+                dialogs.items[len].close();
+            }
+        },
+
+        alert(message, title, buttons, callback, css) {
+            // eslint-disable-next-line no-param-reassign
+            css = (css) ? `dialog-alert ${css}` : 'dialog-alert';
+
+            // add window to dialogs collection
+            // eslint-disable-next-line
+            dialogs.items.push(new dialogs._.create(null, {
+                id: 'alert',
+                mask: true,
+                autoshow: true,
+                fullscreen: false,
+                css,
+                bodycss: 'no-scroll',
+                title: title || 'Alert',
+                html: message,
+                buttons: buttons || ['Ok'],
+                callback: callback || function() {}
+            }));
+        },
+
+        confirm(message, title, callback, css, buttons) {
+
+            // eslint-disable-next-line no-param-reassign
+            css = (css) ? `dialog-confirm ${css}` : 'dialog-confirm';
+            // eslint-disable-next-line no-param-reassign
+            buttons = buttons || ['Yes', 'No'];
+
+            // add window to dialogs collection
+            // eslint-disable-next-line
+            dialogs.items.push(new dialogs._.create(null, {
+                id: 'confirm',
+                mask: true,
+                autoshow: true,
+                fullscreen: false,
+                css,
+                bodycss: 'no-scroll',
+                title: title || 'Confirm',
+                html: message,
+                buttons,
+                callback
+            }));
+        },
+
+        /**
+         * creates an internal dialog window
+         * @param {string} url - url to load into the dialog
+         * @param {object} features - a comma separated list of dialog settings (similar to classic window.open)
+         * Example: dialogs.open('heep://www.google.com','title=My Dialog, width=300px, height=200px, fullscreen=no, mask=true');
+         * @returns {dialog} the opened dialog.
+         */
+        open(url, features) {
+            // <remarks>if title is null and the window was opened from a hyperlink, the inner text of the links is used as the dialog title</remarks>
+
+            // convert features csv into key/value object it its a string
+            const params = (typeof features === 'string') ? dialogs._.convertParamsToObject(features) : features;
+
+            // create the new dialog
+            // eslint-disable-next-line new-cap
+            const dlg = new dialogs._.create(url, params);
+
+            // add to dialogs collection so it can be accessed by name or all
+            dialogs.items.push(dlg);
+
+            // return the custom dialog object for this new window
+            return dlg;
+        },
+
+        /* private stuff */
+        _: {
+
+            convertParamsToObject(features) {
+
+                const params = {
+                    type: 'window'
+                };
+                const items = (features) ? features.split(',') : [];
+
+                for (let i = 0; i < items.length; i++) {
+                    const kvp = items[i].split('=');
+                    const val = kvp[1] || '';
+                    params[kvp[0]] = (val.indexOf('|') > -1) ? val.split('|') : val;
+                }
+
+                return params;
+            },
+
+            // store the old window functions in case we encounter an unsupported browser
+            oldWindowOpen: window.open,
+            oldAlert: window.alert,
+            oldConfirm: window.confirm,
+
+            // get text property name for this browser
+            txtProp: ('textContent' in document.createElement('span')) ? 'textContent' : 'innerText',
+
+            eventDelegate(e) {
+                // eslint-disable-next-line no-param-reassign
+                e = e || event; // resolve event object
+                let el = e.target || e.srcElement; // get event target
+
+                // get parent A tag is it exists
+                el = (el.tagName !== 'A') ? parentByAttribute(el, 'tagName', 'A') : el;
+
+                if (!el || el.tagName !== 'A') {
+                    return;
+                }
+
+                const url = el.href;
+                const settings = el.getAttribute('data-dialog') || null;
+
+                if (!settings) return;
+
+                if (url !== '' && url !== '#' && dialogs.events.onbeforeopen.call(el)) {
+                    // open the link in an internal window (use either title or inner text as the dialog title)
+                    dialogs.open(url, settings);
+
+                    cancelEvent(e);
+                }
+            },
+
+            // creates an internal dialog window
+            create(url, params) {
+                // <summary>creates an internal dialog window</summary>
+                // <param name="url" type="String">the url to load</param>
+                // <param name="name" optional="true" type="String">the unique name to assign to the dialog (required if a call to dialogs.close is needed)</param>
+                // <param name="params" optional="true" type="String">a comma separated list of dialog settings
+                //  <example>title=My Dialog, width=300px, height=200px, fullscreen=true, mask=true|false</example>
+                // </param>
+
+                const dlg = this;
+                const body = document.body;
+
+                // assign parameters
+                dlg.params = params || {};
+                dlg.params.width = (dlg.params.width) ? parseInt(dlg.params.width, 10) : -1;
+                dlg.params.height = (dlg.params.height) ? parseInt(dlg.params.height, 10) : -1;
+                dlg.params.title = (dlg.params.title) ? dlg.params.title : '';
+                dlg.params.fullscreen = (dlg.params.fullscreen === 'true');
+                dlg.params.mask = (dlg.params.mask !== 'false');
+                dlg.params.css = (dlg.params.css) ? dlg.params.css : '';
+                dlg.params.html = (dlg.params.html) ? dlg.params.html : '';
+                dlg.params.text = (dlg.params.text) ? dlg.params.text : '';
+                dlg.params.callback = params.callback || function() {};
+                // dlg.params.autoshow = /false/i.test(params.autoshow);
+                dlg.params.modal = (params.modal === 'true' || params.modal);
+                dlg.params.method = (params.method === 'ajax' && window.ajax) ? 'ajax' : 'iframe';
+                // dlg.params.bodycss = (dlg.params.bodycss) ? dlg.params.bodycss : '' ? ;
+
+                dlg.id = dlg.params.id || `dlg${(new Date()).getTime()}`; // might need to check if it's already in use and if so alter it!?
+
+                if (dlg.params.bodycss) {
+                    addClass(body, dlg.params.bodycss);
+                }
+
+                // create style object if dimensions exist, otherwise fall back to css assigned values
+                const style = (dlg.params.width > -1 && dlg.params.height > -1) ? {
+                    width: `${dlg.params.width}px`,
+                    height: `${dlg.params.height}px`
+                } : {};
+
+                // if the mask is required, insert it
+                if (dlg.params.mask || dlg.params.modal) {
+                    dlg.mask = createElement(body, 'div', {
+                        class: 'dialog-mask {0}-mask'.format(dlg.id)
+                    });
+                }
+
+                if (dlg.mask && !dlg.params.modal) {
+                    dlg.mask.onclick = function(e) {
+                        // eslint-disable-next-line no-param-reassign
+                        e = e || event;
+                        const el = e.target || e.srcElement;
+                        const css = el.className || '';
+
+                        if (hasClass(el, 'dialog-mask')) {
+                            dialogs.get(dlg.id).close();
+                        }
+                    };
+                }
+
+                if (params.title === '') {
+                    dlg.params.css += ' dialog-no-title';
+                }
+
+                // create and insert the window
+                dlg.dialog = createElement(dlg.mask || body, 'div', {
+                    id: dlg.id,
+                    class: 'dialog dialog-offscreen {0}'.format(dlg.params.css),
+                    style
+                });
+                dlg.closeIcon = (!dlg.params.modal) ? createElement(this.dialog, 'span', {
+                    class: 'dialog-close'
+                }, 'x') : null;
+                if (params.title !== '') {
+                    dlg.title = createElement(this.dialog, 'h1', {
+                        class: 'dialog-title'
+                    }, params.title);
+                }
+                dlg.body = createElement(this.dialog, 'div', {
+                    class: 'dialog-body'
+                }, dlg.params.text, dlg.params.html);
+                dlg.loadingMessage = createElement(this.body, 'span', {
+                    class: 'loading-message'
+                });
+                dlg.iframe = createElement(null, 'iframe', {
+                    frameBorder: '0',
+                    border: '0'
+                });
+                dlg.buttons = createElement(null, 'div', {
+                    class: 'dialog-buttons'
+                });
+
+                (dlg.writeButtons = function(buttons) {
+                    clearElement(dlg.buttons);
+
+                    if (buttons && buttons.length > 0) {
+
+                        const buttonClickHandler = function(e) {
+                            // eslint-disable-next-line no-param-reassign
+                            e = e || event; // resolve event object
+                            const el = e.target || e.srcElement; // get event target
+
+                            cancelEvent(e);
+
+                            // TODO: Add check here to only call close if callback did not return false!
+                            dlg.close.call(null, el.innerText || el.textContent);
+                        };
+
+                        for (let i = 0, l = buttons.length; i < l; i++) {
+                            const link = createElement(dlg.buttons, 'a', {
+                                href: '#',
+                                class: `dialog-button dialog-button-${buttons[i].toLowerCase().replace(' ', '-')}`
+                            }, buttons[i]);
+
+                            link.onclick = buttonClickHandler;
+                        }
+
+                        dlg.dialog.appendChild(dlg.buttons);
+                    } else {
+                        // eslint-disable-next-line no-lonely-if
+                        if (dlg.buttons.parentNode) {
+                            dlg.buttons.parentNode.removeChild(dlg.buttons);
+                        }
+                    }
+                })(params.buttons);
+
+                // workout rendered dimensions and centre using negative margins (only if we have dimensions as params)
+                if (dlg.params.width > -1 && dlg.params.height > -1) {
+                    dlg.dialog.style.margin = '-{0}px 0 0 -{1}px'.format(dlg.dialog.offsetHeight / 2, dlg.dialog.offsetWidth / 2);
+                }
+
+                // iframe.onload does not fire in IE, therefore create a method IE can use to check if the iframe has loaded
+                // eslint-disable-next-line consistent-return
+                dlg.iframe._loading = function() {
+                    const frameDoc = dlg.iframe.document || dlg.iframe.contentWindow.document;
+
+                    if (frameDoc && /complete/i.test(frameDoc.readyState)) {
+                        dlg.iframe._loaded();
+                        return true;
+                    }
+                };
+
+                // once the iframe has loaded, this function is called to remove the 'dialog-loading' class allowing the contents to be displayed
+                dlg.iframe._loaded = function() {
+                    dlg.dialog.className = dlg.dialog.className.replace(/ dialog-loading/gi, '');
+                    document.title = dlg._docTitle;
+                };
+
+                // create a load method on the dialog, calling this turns on the loading mask and sets the source
+                dlg.load = function(src, title) {
+
+                    // cache original document title
+                    dlg._docTitle = document.title;
+
+                    // assign the loading message to dialog and document title
+                    document.title = dlg.loadingMessage[dialogs._.txtProp] = dialogs.loadingMessage.format(title);
+
+                    // assign loading class (hides iframe and shows loading gif/message)
+                    dlg.dialog.className += ' dialog-loading';
+
+                    // for all other browsers, when the iframe has loaded call a function to remove the loading class
+                    dlg.iframe.onload = function() {
+                        dlg.iframe._loaded();
+                    };
+
+                    // assign the source
+                    dlg.iframe.src = src;
+                };
+
+                // injects HTML into the dialog
+                dlg.write = function(html, title) {
+
+                    // remove the iframe if it exists
+                    if (dlg.iframe.parentNode) {
+                        dlg.iframe.parentNode.removeChild(dlg.iframe);
+                    }
+
+                    // set the title if its present
+                    if (dlg.title) {
+                        dlg.title[dialogs._.txtProp] = title || dlg.title[dialogs._.txtProp];
+                        // Update dialog CSS
+                        dlg.dialog.classList.remove('dialog-no-title');
+                    }
+
+                    // insert the HTML
+                    clearElement(dlg.body);
+                    html.toDOM(dlg.body);
+                };
+
+                dlg.writeCss = function(cssClass) {
+                    const classList = dlg.dialog.classList;
+                    const classesToRemove = [];
+                    for (let i = 0; i < classList.length; i++) {
+                        const existingClass = classList.item(i);
+                        // TODO: nasty hack over animated and fadeInDown here...
+                        if (existingClass !== 'dialog' && existingClass.indexOf('dialog-') < 0 && existingClass !== 'animated' && existingClass !== 'fadeInDown') {
+                            classesToRemove.push(existingClass);
+                        }
+                    }
+                    classesToRemove.forEach((existingClass) => {
+                        classList.remove(existingClass);
+                    });
+                    classList.add(cssClass);
+                };
+
+                // when executed, attempts to stops the iframe from loading its contents (only works for local content)
+                dlg.stop = function() {
+
+                    try {
+                        // reset document title
+                        if (dlg._docTitle) {
+                            document.title = dlg._docTitle;
+                        }
+
+                        if (window.stop && dlg.iframe.contentWindow && dlg.iframe.contentWindow.stop) {
+                            dlg.iframe.contentWindow.stop();
+                        } else {
+                            const doc = ((dlg.iframe.contentWindow || {}).document || dlg.iframe.contentDocument || dlg.iframe.document);
+                            // TODO: umm. a little crazy, but it must be migrated.
+                            // eslint-disable-next-line no-undef
+                            if (doc && execCommand) {
+                                doc.execCommand('Stop');
+                            }
+                        }
+                    }
+                    // eslint-disable-next-line
+                    catch (e) {}
+                };
+
+                dlg.show = function() {
+
+                    if (!dlg.params.fullscreen && dlg.params.width < 0 && dlg.params.height < 0) {
+
+                        // eslint-disable-next-line
+                        const marginLeft = parseInt(dlg.dialog.offsetWidth / 2);
+                        // eslint-disable-next-line
+                        const marginTop = parseInt(dlg.dialog.offsetHeight / 2);
+
+                        addClass(dlg.dialog, 'dialog-autoshow');
+                    }
+
+                    removeClass(dlg.dialog, 'dialog-offscreen');
+
+                    if (dlg.mask) {
+                        dlg.mask.setAttribute('data-dialog-visible', 'true');
+                    }
+
+                    // fire onshow event handler
+                    if (dialogs.events.onshow) {
+                        dialogs.events.onshow(dlg);
+                    }
+                };
+
+                // when executed, remove the dialog from the browser
+                // eslint-disable-next-line consistent-return
+                dlg.close = function(buttonName) {
+
+                    // stop the iframe from loading...
+                    dlg.stop();
+
+                    // execute callback method
+                    if (dlg.params.callback.call(null, buttonName) === false) return false;
+
+                    // remove mask
+                    dlg.mask.style.display = 'none';
+
+                    if (dlg.mask.parentNode) {
+                        dlg.mask.parentNode.removeChild(dlg.mask);
+                    }
+
+                    dlg.dialog.style.display = 'none';
+                    if (dlg.dialog.parentNode) {
+                        dlg.dialog.parentNode.removeChild(dlg.dialog);
+                    }
+
+                    // remove noscroll from body
+                    if (dlg.params.bodycss) {
+                        removeClass(body, dlg.params.bodycss);
+                    }
+
+                    // find dialog in collection
+                    const idx = dialogs.items.getIndex('id', dlg.id);
+
+                    // remove the dialog from the items collection
+                    if (idx > -1) {
+                        dialogs.items.splice(idx, 1);
+                    }
+                };
+
+                if (!dlg.params.modal) {
+                    dlg.closeIcon.onclick = function() {
+                        dialogs.close.call(null, dlg.id);
+                    };
+                }
+
+                if (dlg.params.autoshow) {
+                    dlg.show();
+                }
+
+                // apply fullscreen styles if required
+                if (dlg.params.fullscreen) {
+                    dlg.dialog.className += ' fullscreen';
+                }
+
+                if (url) {
+
+                    switch (dlg.params.method) {
+                        case 'iframe': {
+                            // insert the iframe
+                            this.body.appendChild(dlg.iframe);
+
+                            // load the url
+                            dlg.load(url, dlg.params.title);
+
+                        } break;
+
+                        case 'ajax': {
+                          // add ajax loading logic here
+                        } break;
+
+                        default: break;
+                    }
+
+                }
+
+                return dlg;
+            }
+        }
+    };
+});

--- a/components/helpers/dialogs.js
+++ b/components/helpers/dialogs.js
@@ -52,7 +52,7 @@ define([
 
         // returns a dialog object where name matches
         get(id) {
-            return dialogs.items.where('id', id, true);
+            return dialogs.items.find(item => item.id === id);
         },
 
         // closes a dialog where the name matches
@@ -192,8 +192,11 @@ define([
                 }
             },
 
+            // TODO: had to disable lint as this is being used as contructor
+            // Object short hand cannot be used as a constructor
             // creates an internal dialog window
-            create(url, params) {
+            // eslint-disable-next-line object-shorthand
+            create: function(url, params) {
                 // <summary>creates an internal dialog window</summary>
                 // <param name="url" type="String">the url to load</param>
                 // <param name="name" optional="true" type="String">the unique name to assign to the dialog (required if a call to dialogs.close is needed)</param>
@@ -235,7 +238,7 @@ define([
                 // if the mask is required, insert it
                 if (dlg.params.mask || dlg.params.modal) {
                     dlg.mask = createElement(body, 'div', {
-                        class: 'dialog-mask {0}-mask'.format(dlg.id)
+                        class: `dialog-mask ${dlg.id}-mask`
                     });
                 }
 
@@ -259,7 +262,7 @@ define([
                 // create and insert the window
                 dlg.dialog = createElement(dlg.mask || body, 'div', {
                     id: dlg.id,
-                    class: 'dialog dialog-offscreen {0}'.format(dlg.params.css),
+                    class: `dialog dialog-offscreen ${dlg.params.css}`,
                     style
                 });
                 dlg.closeIcon = (!dlg.params.modal) ? createElement(this.dialog, 'span', {
@@ -320,7 +323,7 @@ define([
 
                 // workout rendered dimensions and centre using negative margins (only if we have dimensions as params)
                 if (dlg.params.width > -1 && dlg.params.height > -1) {
-                    dlg.dialog.style.margin = '-{0}px 0 0 -{1}px'.format(dlg.dialog.offsetHeight / 2, dlg.dialog.offsetWidth / 2);
+                    dlg.dialog.style.margin = `-${dlg.dialog.offsetHeight / 2}px 0 0 -${dlg.dialog.offsetWidth / 2}px`;
                 }
 
                 // iframe.onload does not fire in IE, therefore create a method IE can use to check if the iframe has loaded
@@ -347,7 +350,8 @@ define([
                     dlg._docTitle = document.title;
 
                     // assign the loading message to dialog and document title
-                    document.title = dlg.loadingMessage[dialogs._.txtProp] = dialogs.loadingMessage.format(title);
+                    // TODO: clean up the string formatting.
+                    document.title = dlg.loadingMessage[dialogs._.txtProp] = `Loading ${title}, please wait...`;
 
                     // assign loading class (hides iframe and shows loading gif/message)
                     dlg.dialog.className += ' dialog-loading';
@@ -391,7 +395,7 @@ define([
                             classesToRemove.push(existingClass);
                         }
                     }
-                    classesToRemove.forEach((existingClass) => {
+                    classesToRemove.forEach(existingClass => {
                         classList.remove(existingClass);
                     });
                     classList.add(cssClass);
@@ -473,7 +477,7 @@ define([
                     }
 
                     // find dialog in collection
-                    const idx = dialogs.items.getIndex('id', dlg.id);
+                    const idx = dialogs.items.findIndex(item => item.id === dlg.id);
 
                     // remove the dialog from the items collection
                     if (idx > -1) {
@@ -521,4 +525,6 @@ define([
             }
         }
     };
+
+    return dialogs;
 });

--- a/components/helpers/has-class.js
+++ b/components/helpers/has-class.js
@@ -1,0 +1,5 @@
+define('has-class', [], () =>
+    function (el, cls) {
+        return el.className.match(new RegExp(`(\\s|^)${cls}(\\s|$)`));
+    }
+);

--- a/components/helpers/remove-class.js
+++ b/components/helpers/remove-class.js
@@ -1,0 +1,9 @@
+define('add-class', ['/components/helpers/has-class.js'], (hasClass) =>
+    function (el, cls) {
+        if (hasClass(el, cls)) {
+            const reg = new RegExp(`\\b${cls}\\b`);
+            // eslint-disable-next-line no-param-reassign
+            el.className = el.className.replace(reg, '').replace('  ', ' ');
+        }
+    }
+);

--- a/examples/ca-file-input.html
+++ b/examples/ca-file-input.html
@@ -5,6 +5,7 @@
     <title>CA FILE INPUT | Web Lab Common UI</title>
     <script src="/bower_components/system.js/dist/system.js"></script>
     <script src="/components/config/index.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/hellpers/dialogs.css">
     <link rel="stylesheet" type="text/css" href="/components/ca-file-input.css">
   </head>
   <body>

--- a/examples/ca-file-input.html
+++ b/examples/ca-file-input.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA FILE INPUT | Web Lab Common UI</title>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/ca-file-input.css">
+  </head>
+  <body>
+    <div class="ca-home">
+      <a id="home" href="/"></a>
+    </div>
+    <div class="ca-title">CA FILE INPUT EXAMPLE</div>
+    <ca-file-input></ca-file-input>
+    <script>
+        SystemJS.import('ca-file-input.js').then(() => {
+            const fileInput = document.querySelector('ca-file-input');
+            fileInput.mediatype='image/gif';
+        });
+    </script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -14,6 +14,7 @@
       <li><a href="/ca-confirm-input"></a></li>
       <li><a href="/ca-context"></a></li>
       <li><a href="/ca-treeview"></a></li>
+      <li><a href="/ca-file-input"></a></li>
     </ol>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "node index.js",
     "postinstall": "bower install",
     "lint": "eslint .",
+    "lint-fix": "eslint . --fix",
     "test": "wct"
   },
   "repository": {

--- a/test/ca-file-input-test.html
+++ b/test/ca-file-input-test.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA FILE INPUT | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/ca-file-input.css">
+  </head>
+  <body>
+    <test-fixture id="file-input">
+      <template>
+        <ca-file-input></ca-file-input>
+      </template>
+    </test-fixture>
+    <script>
+        suite('<ca-file-input>', () => {
+            let fileInput;
+
+            // TODO: CREATE TESTS, migrated and there were none.
+            setup(done => {
+                SystemJS.import('ca-file-input.js').then(() => {
+                    fileInput = fixture('file-input');
+                    done();
+                });
+            });
+        });
+        a11ySuite('file-input');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
NOTE: there is some coupling between this merge request and https://github.com/cambridgeweblab/common-ui/pull/10.

Because both rely on dialogs.js, I had to perform some hacky git  magic to share dialogs.js(and helpers) without duplicating effort. Github will block the request if there are conflicts, so it should be fine.

Migrated from the old repo. No tests were carried over.
The example in the old didn't work and has been adjusted to work.
There is a huge flaw in this file. Since most of the work is done in the
createdCallback. <ca-file-input mediatype='jpeg'></ca-file-input> will result in an error.
MediaType at this point will be null. Most of this work ought to be moved to the connected callback.

components/ca-file-input.css -> copied from old repo.
components/ca-file-input.js -> top and tail from old repo.
components/helpers/add-class.js -> migrated old repo / helpers.js
components/helpers/add-event.js -> migrated old repo / helpers.js
components/helpers/cancel-event.js -> migrated old repo / helpers.js
components/helpers/clear-element.js -> migrated old repo / helpers.js
components/helpers/dialogs.js -> migrated old repo / dialogs.js
components/helpers/has-class.js -> migrated old repo / helpers.js
components/helpers/parent-by-attribute.js -> migrated old repo / helpers.js
components/helpers/remove-class.js -> migrated old repo / helpers.js
examples/ca-file-input.html -> migrated and fixed.
package.json -> add lint fix script.
test/ca-file-input-test.html -> placeholder