### PR TITLE
Migrating ca-object-list

### DIFF
--- a/components/ca-object-list.css
+++ b/components/ca-object-list.css
@@ -1,0 +1,29 @@
+ca-object-list {
+    display: block;
+    position: relative;
+    overflow: hidden;
+}
+
+ca-object-list button {
+    display: inline-block;
+    overflow: hidden;
+    color: #fff;
+    cursor: pointer;
+    background-color: #333;
+    border: 1px solid #333;
+    padding: 0.5em 2em;
+    border-radius: 5px;
+    text-align: center;
+}
+
+ca-object-list ca-summary {
+    float: left;
+}
+
+ca-object-list ca-summary p {
+    text-align: left;
+}
+
+ca-object-list ca-summary p[data-label]:before {
+    display: none;
+}

--- a/components/ca-object-list.js
+++ b/components/ca-object-list.js
@@ -20,6 +20,17 @@ define([
      */
     class ObjectList extends HTMLElement {
         /**
+         * @description Executes when the element is attached to the DOM
+         * @returns {undefined} calls render if condition is met
+         */
+        attachedCallback() {
+            // Render the component now it has been added to the DOM, if we have a schema.
+            if (this.schema) {
+                this.render();
+            }
+        }        
+
+        /**
          * Gets title to be used for these items
          * @returns {string} title, title to get.
          */
@@ -69,17 +80,6 @@ define([
         set value(value) {
             this._property = value;
             if (this.parentNode && this._schema) {
-                this.render();
-            }
-        }
-
-        /**
-         * @description Executes when the element is attached to the DOM
-         * @returns {undefined} calls render if condition is met
-         */
-        attachedCallback() {
-            // Render the component now it has been added to the DOM, if we have a schema.
-            if (this.schema) {
                 this.render();
             }
         }

--- a/components/ca-object-list.js
+++ b/components/ca-object-list.js
@@ -1,0 +1,181 @@
+define([
+    './helpers/create-element.js',
+    './helpers/clear-element.js',
+    './helpers/cancel-event.js',
+    './helpers/fire-event.js',
+    './helpers/dialogs.js',
+    './ca-form.js',
+    './ca-select.js',
+    './ca-summary.js',
+    './ca-property.js',
+    'document-register-element'
+], (createElement, clearElement, cancelEvent, fireEvent, dialogs) => {
+
+    /**
+     * @exports ca-object-list
+     * @description A custom HTML element (Web Component) that can be created using
+     * document.createElement('ca-object-list') or included in a HTML page as an element.
+     * This component is a way of displaying a list of complex objects with the ability to add and remove from the list.
+     * The component reuses ca-summary to display existing objects, and ca-form to add new objects.
+     */
+    class ObjectList extends HTMLElement {
+        /**
+         * Gets title to be used for these items
+         * @returns {string} title, title to get.
+         */
+        get title() {
+            return this.getAttribute('title');
+        }
+
+        /**
+         * Sets title to be used for these items
+         * @param {string} title, title to set.
+         */
+        set title(title) {
+            this.setAttribute('title', title);
+        }
+
+        /**
+         * Gets the JSON schema for each item in the object list
+         * @returns {object} schema
+         */
+        get schema () {
+            return this._schema;
+        }
+
+        /**
+         * Sets the JSON schema for each item in the object list
+         * @param {object} schema that drives render.
+         */
+        set schema(schema) {
+            this._schema = schema;
+            if (this.parentNode) { // already attached
+                this.render();
+            }
+        }
+
+        /**
+         * Gets the object array being managed by this component
+         * @returns {Array} value
+         */
+        get value() {
+            return Array.from(this.querySelectorAll('ca-summary')).map(record => record.data);
+        }
+
+        /**
+         * Sets the object array being managed by this component
+         * @param {Array} value, array for data.
+         */
+        set value(value) {
+            this._property = value;
+            if (this.parentNode && this._schema) {
+                this.render();
+            }
+        }
+
+        /**
+         * @description Executes when the element is attached to the DOM
+         * @returns {undefined} calls render if condition is met
+         */
+        attachedCallback() {
+            // Render the component now it has been added to the DOM, if we have a schema.
+            if (this.schema) {
+                this.render();
+            }
+        }
+
+        /**
+         * @description Show the form to add a new object
+         * @returns {undefined} nothing, shows form.
+         */
+        showForm () {
+            const dialogId = `${this.id}-addDialog`;
+
+            if (!dialogs.get(dialogId)) {
+                const dlg = dialogs.open('', {
+                    id:	dialogId,
+                    autoshow:	false,
+                    title:	`Add ${this.title}`,
+                    css: `animated fadeInDown ${this.id}` || '',
+                    bodycss: 'no-scroll',
+                    buttons: ['Cancel', 'Add'],
+                    callback: (btnName) => {
+                        if (btnName === 'Add') {
+                            // This makes me cry, but refactoring is the only solution to this.
+                            // eslint-disable-next-line no-use-before-define
+                            if (form.isValid()) {
+                                const createForm = document.querySelector(`#${this.id}-addDialog form`);
+                                if (createForm) {
+                                    fireEvent(createForm, 'submit');
+                                }
+                                return true;
+                            }
+                            // dont allow the dialog to close
+                            return false;
+                        }
+                        return true;
+                    }
+                });
+                // This makes me cry, but refactoring is the only solution to this.
+                // eslint-disable-next-line no-undef
+                const form = createElement(dlg.body, 'ca-form');
+
+                // dont show the dialog until all data fetched and contents rendered
+                form.onrendercomplete = () => {
+                    // This makes me cry, but refactoring is the only solution to this.
+                    // eslint-disable-next-line no-undef
+                    dlg.show();
+                };
+
+                form.columns = 1;
+                form.className = this.id;
+
+                form.onsave = () => {
+                    this.addCard(form.getData());
+                };
+                form.schema = [this.schema];
+                this._isFormShowing = true;
+            }
+        }
+
+        /**
+         * @description Renders the element (invoked via render.call(this))
+         * @returns {undefined} renders to the dom.
+         */
+        render() {
+            clearElement(this);
+            this._button = createElement(this, 'button', { class: 'ca-object-list-add' }, 'Add');
+            this._button.onclick = this.addButtonHandler.bind(this);
+            if (this._property && Array.isArray(this._property)) {
+                for (let i = 0, l = this._property.length; i < l; i++) {
+                    this.addCard(this._property[i]);
+                }
+            }
+        }
+
+        /**
+         * @description Adds a card with a single record to the rendered view.
+         * @param {object} data the data for the record
+         * @returns {undefined} nothing
+         */
+        addCard(data) {
+            const card = createElement(null, 'ca-summary', { type: 'card', itemsPerCol: 100 });
+            card.schema = this.schema;
+            card.data = data;
+            this.insertBefore(card, this._button);
+        }
+
+        /**
+         * @description button handler.
+         * @param {event} e, event.
+         * @returns {undefined} nothing. Shows form.
+         */
+        addButtonHandler(e) {
+            cancelEvent(e);
+            this.showForm();
+        }
+    }
+
+    // Register our new element
+    document.registerElement('ca-object-list', ObjectList);
+});

--- a/examples/ca-object-list.html
+++ b/examples/ca-object-list.html
@@ -1,0 +1,75 @@
+<!doctype>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>CA OBJECT LIST | Web Lab Common UI</title>
+        <script src="/bower_components/system.js/dist/system.js"></script>
+        <script src="/components/config/index.js"></script>
+        <link rel="stylesheet" type="text/css" href="/examples/index.css">
+        <link rel="stylesheet" type="text/css" href="/components/ca-object-list.css">
+        <link rel="stylesheet" type="text/css" href="/components/ca-summary.css">
+        <link rel="stylesheet" type="text/css" href="/components/ca-form.css">
+        <link rel="stylesheet" type="text/css" href="/components/ca-select.css">
+        <link rel="stylesheet" type="text/css" href="/components/helpers/dialogs.css">
+        <style>
+            ca-object-list {
+              position: inherit;
+              overflow: visible;
+            }
+
+            ca-object-list ca-summary {
+              margin-bottom: 20px;
+            }
+
+            ca-object-list button {
+                clear: both;
+                display: block;
+            }
+
+            ca-object-list ca-summary[data-type="card"] {
+                display: block;
+                margin: 10px;
+            }
+        </style>
+
+    </head>
+
+    <body>
+        <div class="ca-home">
+            <a id="home" href="../"></a>
+        </div>
+
+        <div class="ca-title">CA OBJECT LIST EXAMPLE</div>
+        <ca-object-list name="example" id="example" title="example"></ca-object-list>
+
+        <script>
+            SystemJS.import('ca-object-list.js').then(() => {
+                const objectList = document.querySelector('ca-object-list');
+                objectList.schema = {
+                    type: 'object',
+                    id: 'id',
+                    properties: {
+                        colour: {
+                            type: 'string',
+                            id: 'order:040_colour',
+                            required: true,
+                            description: 'The colour of the marks',
+                            title: 'Colour',
+                            enum: ['Red', 'Green', 'Purple', 'Pencil']
+                        },
+                        marks: {
+                            type: 'number',
+                            id: 'order:050_marks',
+                            description: 'The marks',
+                            title: 'Marks',
+                            required: true
+                        }
+                    }
+                };
+                objectList.value = [
+                    { colour: 'Red', marks: 22 }
+                ];
+            });
+        </script>
+    </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "node index.js",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
-    "test": "wct"
+    "test": "wct",
+    "bower-install": "bower install"
   },
   "repository": {
     "type": "git",

--- a/test/ca-object-list-test.html
+++ b/test/ca-object-list-test.html
@@ -26,7 +26,7 @@
                 });
             });
         });
-        a11ySuite('cobject-list');
+        a11ySuite('object-list');
     </script>
   </body>
 </html>

--- a/test/ca-object-list-test.html
+++ b/test/ca-object-list-test.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CA TEL | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/system.js/dist/system.js"></script>
+    <script src="/components/config/index.js"></script>
+    <link rel="stylesheet" type="text/css" href="/components/ca-object-list.css">
+  </head>
+  <body>
+    <test-fixture id="object-list">
+      <template>
+        <ca-object-list></ca-object-list>
+      </template>
+    </test-fixture>
+    <script>
+        suite('<ca-object-list>', () => {
+            let caObjectList;
+
+            // TODO: CREATE TESTS, there were none associated with the original component
+            setup(done => {
+                SystemJS.import('ca-object-list.js').then(() => {
+                    object = fixture('ca-object-list');
+                    done();
+                });
+            });
+        });
+        a11ySuite('cobject-list');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- components/ca-object-list.css -> copy pasta
- components/ca-object-list.js -> migrated to module and es6
- examples/ca-object-list.html -> new example, wasn't in the old code base.
- package.json -> added bower task
- test/ca-object-list-test.html -> placeholder