### PR TITLE
Resolve issue with freezing tests

### DIFF
--- a/components/ca-barcode-scanner.html
+++ b/components/ca-barcode-scanner.html
@@ -1,7 +1,7 @@
 <link rel="import" href="./helpers/create-element.html">
 <script>
 /* global cordova */
-define('create-element', ['create-element'], (createElement) => {
+define('barcode-scanner', ['create-element'], (createElement) => {
     /**
      * @exports ca-barcode-scanner
      * @description A custom HTML element (Web Component) that can be created using


### PR DESCRIPTION
The issue is that `npm test` was freezing due to two AMD modules named create-element. This was a bug introducing by needing to name all modules. ca-barcode-scanner.html was named wrongly.