### PR TITLE
Add new ca-auth component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "tests"
   ],
   "dependencies": {
+    "app-router": "^2.7.2",
     "pikaday": "^1.5.1",
     "imd": "PolymerLabs/IMD#master",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.24"

--- a/components/ca-auth.html
+++ b/components/ca-auth.html
@@ -1,0 +1,122 @@
+<script>
+    define('ca-auth', [], () => {
+        const REPLACE_CURRENT_PAGE = { replace: true };
+
+        /**
+         * Non-UI component which handles authorization headers on all <ca-resource> requests contained within it.
+         * If there is an <app-router> contained in this element, it also redirects the view to a login page when a
+         * request is not authorized, and then back afterwards.
+         */
+        class CaAuthElement extends HTMLElement {
+            /**
+             * @returns {string} the app-router path to which to redirect for a login
+             */
+            get loginPath() {
+                return this.getAttribute('login-path');
+            }
+
+            /**
+             * @param {string} value, the app-router path to which to redirect for a login
+             */
+            set loginPath(value) {
+                this.setAttribute('login-path', value);
+            }
+
+            /**
+             * @returns {string} the type to add to the Authorization header e.g. Bearer which is the default
+             */
+            get type() {
+                return this.getAttribute('type') || 'Bearer';
+            }
+
+            /**
+             * @param {string} value, the type to add to the Authorization header e.g. Bearer
+             */
+            set type(value) {
+                this.setAttribute('type', value);
+            }
+
+            /**
+             * @returns {string} the key to use with session storage to hold the credentials e.g. webapiCredentials which is the default
+             */
+            get credentialsKey() {
+                return this.getAttribute('credentials-key') || 'webapiCredentials';
+            }
+
+            /**
+             * @param {string} value, the key to use with session storage to hold the credentials e.g. webapiCredentials
+             */
+            set credentialsKey(value) {
+                this.setAttribute('credentials-key', value);
+            }
+
+            /**
+             * @returns {string} the credentials to add to the Authorization header e.g. a JWT access token
+             */
+            get credentials() {
+                return sessionStorage.getItem(this.credentialsKey);
+            }
+
+            /**
+             * @param {string} value, the credentials to add to the Authorization header e.g. a JWT access token
+             */
+            set credentials(value) {
+                sessionStorage.setItem(this.credentialsKey, value);
+                if (this._restorePath) {
+                    this._restorePath();
+                }
+            }
+
+            /**
+             * Attach event listeners to listen for ca-resource events.
+             * @return {undefined} nothing
+             */
+            attachedCallback() {
+                const appRouter = this.querySelector('app-router');
+
+                // Listener to add Authorization headers while fetching.
+                this.addEventListener('ca-resource-fetching', e => {
+                    const credentials = this.credentials;
+                    if (credentials) {
+                        const init = e.detail.init;
+                        const headers = init.headers || new Headers();
+                        headers.append('Authorization', `${this.type} ${credentials}`);
+                        init.headers = headers;
+                    }
+                });
+
+                // Listener to redirect to login when necessary.
+                this.addEventListener('ca-resource-unauthorized', e => {
+                    if (appRouter && this.loginPath) {
+                        appRouter.go(this.loginPath, REPLACE_CURRENT_PAGE);
+                    }
+                });
+
+                if (appRouter) {
+                    // Listener to keep track of where we were before we redirected to login and create a function to go
+                    // back there.
+                    this._restorePath = () => appRouter.go('/', REPLACE_CURRENT_PAGE); // Default to root path.
+                    appRouter.addEventListener('activate-route-start', e => {
+                        if (e.detail.path !== this.loginPath) {
+                            this._restorePath = () => appRouter.go(e.detail.path, REPLACE_CURRENT_PAGE);
+                        }
+                    });
+
+                }
+
+            }
+
+            /**
+             * Stop listening for events.
+             * @returns {undefined} nothing
+             */
+            detachedCallback() {
+                // TODO: implement this.
+            }
+
+        }
+
+        // Register our new element
+        document.registerElement('ca-auth', CaAuthElement);
+    });
+</script>

--- a/examples/ca-auth.html
+++ b/examples/ca-auth.html
@@ -1,0 +1,102 @@
+<!doctype>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CA AUTH | Web Lab Common UI</title>
+    <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="/bower_components/imd/imd.html">
+    <link rel="import" href="/bower_components/app-router/app-router.html">
+    <link rel="import" href="/components/ca-resource.html">
+    <link rel="import" href="/components/ca-auth.html">
+    <link href="/examples/index.css" rel="stylesheet">
+    <style>
+        app-router {
+            display: block;
+            margin: 1em;
+            border: solid mediumslateblue 2px;
+            padding: 4px;
+        }
+    </style>
+</head>
+
+<body>
+<div class="ca-home">
+    <a id="home" href="../index.html"></a>
+</div>
+
+<div class="ca-title">CA AUTH</div>
+
+<h2>Current authentication</h2>
+<p>Your current authentication token is:
+    <span id="credentials"></span>
+    <a href="javascript:refreshCredentials();">Refresh</a>
+    <a href="javascript:clearCredentials();">Clear</a>.
+</p>
+
+<h2>With app-router</h2>
+
+<ca-auth type="Example" credentials-key="example-credentials" login-path="/login">
+    <app-router mode="hash">
+        <app-route path="/login">
+            <template>
+                <p>This is the login page.</p>
+                <p><a href="javascript:setCredentials();">Log in with valid credentials</a></p>
+            </template>
+        </app-route>
+        <app-route path="/secure">
+            <template>
+                <p>This is a page hosting a <span style="color: darkred">secured</span> resource</p>
+                <ca-resource href="/secure"></ca-resource>
+                <p><a href="#/insecure">Why not try to access a unsecured one?</a></p>
+            </template>
+        </app-route>
+        <app-route path="/insecure">
+            <template>
+                <p>This is a page hosting a <span style="color: darkgreen">unsecured</span> resource</p>
+                <ca-resource href="/insecure"></ca-resource>
+                <p><a href="#/secure">Why not try to access a secure one?</a></p>
+            </template>
+        </app-route>
+        <app-route path="*" redirect="/insecure"></app-route>
+    </app-router>
+</ca-auth>
+
+<h2>Without app-router</h2>
+
+<ca-auth type="Example" credentials-key="example-credentials" login-page="/login">
+    <a href="javascript:fetchUnrouted()">Fetch secured resource</a>
+    <ca-resource id="fetch-unrouted-resource"></ca-resource>
+    <div id="fetch-unrouted-result"></div>
+</ca-auth>
+
+<script>
+    function refreshCredentials() {
+        document.getElementById('credentials').textContent = sessionStorage.getItem('example-credentials');
+    }
+
+    function clearCredentials() {
+        sessionStorage.removeItem('example-credentials');
+        refreshCredentials();
+    }
+
+    function setCredentials() {
+        document.querySelector('ca-auth').credentials = 'letmein';
+    }
+
+    function fetchUnrouted() {
+        const resource = document.getElementById('fetch-unrouted-resource');
+        const result = document.getElementById('fetch-unrouted-result');
+        result.innerHTML = '';
+        resource.addEventListener('ca-resource-fetched', e => {
+            result.textContent = `${e.detail.status} ${e.detail.statusText}`;
+        });
+        resource.href = '';
+        resource.href = '/secure';
+    }
+
+    window.addEventListener('HTMLImportsLoaded', () => {
+        refreshCredentials();
+    });
+</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -40,6 +40,7 @@
       <li><a href="/ca-override"></a></li>
       <li><a href="/ca-sortable-list"></a></li>
       <li><a href="/ca-resource"></a></li>
+      <li><a href="/ca-auth"></a></li>
     </ol>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -17,6 +17,13 @@ server
     .use('/examples', express.static(path.join(__dirname, 'examples')))
     .use('/components', express.static(path.join(__dirname, 'components')))
     .get('/', (req, res) => res.sendFile(path.resolve(__dirname, 'examples', 'index.html')))
+    .get('/insecure', (req, res) => res.json({ success: true }))
+    .get('/secure', (req, res) => {
+        if (req.headers.authorization === 'Example letmein') {
+            return res.json({ success: true });
+        }
+        return res.status(401).send('Unauthorized');
+    })
     .get('/:component', (req, res) => {
         const component = req.params.component;
         res.sendFile(path.resolve(__dirname, 'examples', `${component}${component.endsWith('.html') ? '' : '.html'}`));

--- a/test/ca-auth-test.html
+++ b/test/ca-auth-test.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CA AUTH | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="/bower_components/imd/imd.html">
+    <link rel="import" href="/bower_components/app-router/app-router.html">
+    <link rel="import" href="/components/ca-auth.html">
+    <link rel="import" href="/components/ca-resource.html">
+</head>
+<body>
+<test-fixture id="ca-auth">
+    <template>
+        <ca-auth type="Auth1" credentials-key="auth1" login-path="/login">
+            <app-router mode="hash">
+                <app-route path="/login">
+                    <template>
+                        <span id="login"></span>
+                    </template>
+                </app-route>
+                <app-route path="/home">
+                    <template>
+                        <span id="home">
+                            <ca-resource></ca-resource>
+                        </span>
+                    </template>
+                </app-route>
+                <app-route path="*" redirect="/home"></app-route>
+            </app-router>
+        </ca-auth>
+    </template>
+</test-fixture>
+<script>
+    suite('<ca-auth>', () => {
+        let caAuth;
+
+        setup(done => {
+            sessionStorage.clear();
+            caAuth = fixture('ca-auth');
+            document.querySelector('app-router').go('/');
+            done();
+        });
+
+        test('stores and retrieve credentials using the key specified', done => {
+            caAuth.innerHTML = '';
+            caAuth.credentials = 'open sesame';
+            expect(sessionStorage.getItem('auth1')).to.equal('open sesame');
+            done();
+        });
+
+        test('provides credentials in response to a ca-resource-fetching event (no app-router)', done => {
+            caAuth.type= 'Auth2';
+            caAuth.credentials = 'open sesame';
+            caAuth.innerHTML = '<ca-resource></ca-resource>';
+
+            const detail = { href: 'about:null', init: {} };
+            const cancelled = !caAuth.querySelector('ca-resource').dispatchEvent(new CustomEvent('ca-resource-fetching', {
+                detail,
+                bubbles: true,
+                cancelable: true
+            }));
+            expect(cancelled).to.be.false;
+            expect(detail.init.headers).to.not.be.undefined;
+            expect(detail.init.headers.get('Authorization')).to.equal('Auth2 open sesame');
+            done();
+        });
+
+        test('displays a login page in response to a ca-resource-unauthorized event', done => {
+            document.getElementById('home').querySelector('ca-resource').dispatchEvent(new CustomEvent('ca-resource-unauthorized', {
+                bubbles: true
+            }));
+            expect(document.getElementById('home')).to.be.null;
+            expect(document.getElementById('login')).to.not.be.null;
+            done();
+        });
+
+        test('reverts to the previous page when credentials are set', done => {
+            document.getElementById('home').querySelector('ca-resource').dispatchEvent(new CustomEvent('ca-resource-unauthorized', {
+                bubbles: true
+            }));
+            caAuth.credentials = 'some kind of password';
+            expect(document.getElementById('home')).to.not.be.null;
+            expect(document.getElementById('login')).to.be.null;
+            done();
+        });
+    });
+    a11ySuite('ca-auth');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Handles providing credentials to ca-resource from session storage, and also (if used in conjunction with app-router) redirecting to a login view and back again.