### PR TITLE
Add new ca-oauth2-client component to encapsulate token request

### DIFF
--- a/components/ca-oauth2-client.html
+++ b/components/ca-oauth2-client.html
@@ -29,6 +29,14 @@
             }
 
             /**
+             * @return {Array<String>} list of valid values for the {@link type} property.
+             */
+            static get types() {
+                // TODO: add the rest of the valid values to this list once implemented ('code', 'implicit' or 'client')
+                return ['password'];
+            }
+
+            /**
              * Called when any attribute is changed on the element, but is only interested in the {@link CaOAuth2ClientElement.observedAttributes}.
              * Will trigger the authorization request if the element has sufficient attributes set to initiate a flow.
              * @param {string} attrName - the name of the attribute to have changed
@@ -62,14 +70,16 @@
              * @return {string} the grant type, defaults to 'password'
              */
             get type() {
-                return this.getAttribute('type') || 'password';
+                return CaOAuth2ClientElement.types.includes(this.getAttribute('type')) ? this.getAttribute('type') : 'password';
             }
 
             /**
-             * @param {string} value, the grant type - one of 'password', 'code', 'implicit' or 'client'.
+             * @param {string} value, the grant type - one of the values listed in {@link #types} - 'password', 'code', 'implicit' or 'client'.
              */
             set type(value) {
-                this.setAttribute('type', value);
+                if (CaOAuth2ClientElement.types.includes(value)) {
+                    this.setAttribute('type', value);
+                }
             }
 
             /**

--- a/components/ca-oauth2-client.html
+++ b/components/ca-oauth2-client.html
@@ -1,0 +1,211 @@
+<script>
+    define('ca-oauth2-client', [], () => {
+
+        /**
+         * This non-UI component acts as an OAuth2 client.
+         * If it is used in conjunction with <ca-auth> then it can automatically provide access token credentials post-authentication.
+         * This first version supports password flow only and is therefore usually used in conjunction with a conventional HTML form.
+         * The component will immediately initiate the OAuth2 authorization process once it has sufficient attributes set.
+         * This component requires {@code Element.closest()}, so {@link https://github.com/jonathantneal/closest polyfill it} for IE.
+         * The following events are fired by this element:
+         *
+         * <dl>
+         * <dt>ca-oauth2-authorized</dt>
+         * <dd>Fired when authorization has been successful, before the credentials are provided to <ca-auth>.
+         * Call {@code Event.preventDefault()} to stop this happening. Event detail is the OAuth2 token response.</dd>
+         * <dt>ca-oauth2-unauthorized</dt>
+         * <dd>Fired when authorization has been unsuccessful. Event detail is the error message.</dd>
+         * </dl>
+         *
+         * @see https://www.digitalocean.com/community/tutorials/an-introduction-to-oauth-2
+         */
+        class CaOAuth2ClientElement extends HTMLElement {
+            /**
+             * observedAttributes - get a list of attributes that should be considered in the callback.
+             * @return {Array} list of attributes that should be considered in the callback.
+             */
+            static get observedAttributes() {
+                return ['href', 'type', 'client-id', 'client-secret', 'username', 'password'];
+            }
+
+            /**
+             * Called when any attribute is changed on the element, but is only interested in the {@link CaOAuth2ClientElement.observedAttributes}.
+             * Will trigger the authorization request if the element has sufficient attributes set to initiate a flow.
+             * @param {string} attrName - the name of the attribute to have changed
+             * @param {string} oldVal - the old value of the attribute
+             * @param {string} newVal - the new value of the attribute
+             * @returns {undefined} nothing
+             */
+            attributeChangedCallback(attrName, oldVal, newVal) {
+                if (CaOAuth2ClientElement.observedAttributes.includes(attrName)) {
+                    if (this.ready()) {
+                        this.requestToken();
+                    }
+                }
+            }
+
+            /**
+             * @return {string} the URI of the authorization server's endpoint (token endpoint for password grant)
+             */
+            get href() {
+                return this.getAttribute('href');
+            }
+
+            /**
+             * @param {string} value, the URI of the authorization server's endpoint (token endpoint for password grant)
+             */
+            set href(value) {
+                this.setAttribute('href', value);
+            }
+
+            /**
+             * @return {string} the grant type, defaults to 'password'
+             */
+            get type() {
+                return this.getAttribute('type') || 'password';
+            }
+
+            /**
+             * @param {string} value, the grant type - one of 'password', 'code', 'implicit' or 'client'.
+             */
+            set type(value) {
+                this.setAttribute('type', value);
+            }
+
+            /**
+             * @return {string} the string which identifies this application with the authorization server
+             */
+            get clientId() {
+                return this.getAttribute('client-id');
+            }
+
+            /**
+             * @param {string} value, the string which identifies this application with the authorization server
+             */
+            set clientId(value) {
+                this.setAttribute('client-id', value);
+            }
+
+            /**
+             * The client secret should never normally be required in a browser client as it cannot be kept secret.
+             * However, some OAuth2 implementations (particularly Spring Security) require it (redundantly) for the password grant flow.
+             * @return {string} the string which authenticates the identity of this application alongside the {@link clientId}
+             */
+            get clientSecret() {
+                return this.getAttribute('client-secret');
+            }
+
+            /**
+             * The client secret should never normally be required in a browser client as it cannot be kept secret.
+             * However, some OAuth2 implementations (particularly Spring Security) require it (redundantly) for the password grant flow.
+             * @param {string} value, the string which authenticates the identity of this application alongside the {@link clientId}
+             */
+            set clientSecret(value) {
+                this.setAttribute('client-secret', value);
+            }
+
+            /**
+             * @return {string} the username of the authenticating user, for password flow from trusted client applications only
+             */
+            get username() {
+                return this.getAttribute('username');
+            }
+
+            /**
+             * @param {string} value, the username of the authenticating user, for password flow from trusted client applications only
+             */
+            set username(value) {
+                this.setAttribute('username', value);
+            }
+
+            /**
+             * @return {string} the password of the authenticating user, for password flow from trusted client applications only
+             */
+            get password() {
+                return this.getAttribute('password');
+            }
+
+            /**
+             * @param {string} value, the password of the authenticating user, for password flow from trusted client applications only
+             */
+            set password(value) {
+                this.setAttribute('password', value);
+            }
+
+            /**
+             * Will trigger the authorization request if the element has sufficient attributes set to initiate a flow.
+             * @return {undefined} nothing
+             */
+            attachedCallback() {
+                if (this.ready()) {
+                    this.requestToken();
+                }
+            }
+
+            /**
+             * Checks if we have sufficient attributes set to initiate an authorization flow.
+             * @return {boolean} if sufficient attributes are set
+             */
+            ready() {
+                // Check if we're in a state where we can request a token
+                return (this.type === 'password' && this.href && this.clientId && this.clientSecret && this.username && this.password);
+            }
+
+            /**
+             * Initiates an authorization flow if we are attached to the current browser docuemnt.
+             * Dispatches a bubbling, cancellable {@code ca-oauth2-authorized} event if successful, or a {@code ca-oauth2-unauthorized} event if not.
+             * If the {@code ca-oauth2-authorized} event is not cancelled then the nearest ancestor <ca-auth> element (if any)
+             * will have its {@link CaAuthElement#credentials} set.
+             * @return {Promise|null} promise, or null if the flow was not initiated
+             */
+            requestToken() {
+                // Don't do anything if we're not attached to a document.
+                if (!document.contains(this)) return null;
+
+                return this.passwordGrant()
+                    .then(res => {
+                        if (res.access_token) {
+                            if (this.dispatchEvent(new CustomEvent('ca-oauth2-authorized', {
+                                detail: res,
+                                bubbles: true,
+                                cancelable: true
+                            }))) {
+                                const caAuth = this.closest('ca-auth');
+                                if (caAuth) {
+                                    caAuth.credentials = res.access_token;
+                                }
+                            }
+                        } else {
+                            throw Error(res.error);
+                        }
+                    })
+                    .catch(error => {
+                        this.dispatchEvent(new CustomEvent('ca-oauth2-unauthorized', { detail: error }));
+                    });
+            }
+
+            /**
+             * Initiates a password grant authorization with client credentials passed as a Basic authentication header
+             * and user credentials passed as form parameters.
+             * @return {Promise} promise of a password grant response including an access_token and other fields.
+             */
+            passwordGrant() {
+                const headers = new Headers();
+                const clientCredentials = `${this.clientId}:${this.clientSecret}`;
+                const body = `username=${window.encodeURIComponent(this.username)}&password=${window.encodeURIComponent(this.password)}&grant_type=password`;
+                headers.append('Content-Type', 'application/x-www-form-urlencoded');
+                headers.append('Authorization', `Basic ${window.btoa(clientCredentials)}`);
+                const init = { method: 'POST', headers, body };
+                return window.fetch(this.href, init).then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                    throw Error(`${response.status} ${response.statusText}`);
+                });
+            }
+        }
+
+        // Register our new element
+        document.registerElement('ca-oauth2-client', CaOAuth2ClientElement);
+    });
+</script>

--- a/examples/ca-oauth2-client.html
+++ b/examples/ca-oauth2-client.html
@@ -1,0 +1,81 @@
+<!doctype>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CA OAUTH2 CLIENT | Web Lab Common UI</title>
+    <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="/bower_components/imd/imd.html">
+    <link rel="import" href="/components/ca-oauth2-client.html">
+    <link rel="import" href="/components/ca-auth.html">
+    <link href="/examples/index.css" rel="stylesheet">
+</head>
+
+<body>
+<div class="ca-home">
+    <a id="home" href="../index.html"></a>
+</div>
+
+<div class="ca-title">CA OAUTH2 CLIENT</div>
+
+<h2>Current authentication</h2>
+<p>Your current authentication token is:
+    <span id="credentials"></span>
+    <a href="javascript:refreshCredentials();">Refresh</a>
+    <a href="javascript:clearCredentials();">Clear</a>.
+</p>
+
+<h2>Password grant</h2>
+<ca-auth type="Example" credentials-key="example-credentials" login-path="/login">
+    <ca-oauth2-client type="password"></ca-oauth2-client>
+</ca-auth>
+
+<form id="password_form" onsubmit="return authorize()">
+    <p><label>Token endpoint: <input type="text" name="href"></label></p>
+    <p><label>Client ID: <input type="text" name="client-id"></label></p>
+    <p><label>Client Secret: <input type="text" name="client-secret"></label></p>
+    <p><label>Username: <input type="text" name="username"></label></p>
+    <p><label>Password: <input type="password" name="password"></label></p>
+    <p><input type="submit" value="Authorize"></p>
+</form>
+
+<div id="authorize-result"></div>
+
+<script>
+    const client = document.querySelector('ca-oauth2-client[type=password]');
+    const result = document.getElementById('authorize-result');
+
+    function refreshCredentials() {
+        document.getElementById('credentials').textContent = sessionStorage.getItem('example-credentials');
+    }
+
+    function clearCredentials() {
+        sessionStorage.removeItem('example-credentials');
+        refreshCredentials();
+    }
+
+    function authorize() {
+        result.innerHTML = '';
+
+        const inputs = document.getElementById('password_form').querySelectorAll('input');
+        for (let i = 0; i < inputs.length; i++) {
+            const input = inputs[i];
+            if (input.name && input.value) {
+                client.setAttribute(input.name, input.value);
+            }
+        }
+
+        return false;
+    }
+
+    client.addEventListener('ca-oauth2-authorized', e => {
+        result.textContent = `Authorized with token ${e.detail.access_token}`;
+    });
+
+    client.addEventListener('ca-oauth2-unauthorized', e => {
+        result.textContent = e.detail;
+    });
+
+    refreshCredentials();
+</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -41,6 +41,7 @@
       <li><a href="/ca-sortable-list"></a></li>
       <li><a href="/ca-resource"></a></li>
       <li><a href="/ca-auth"></a></li>
+      <li><a href="/ca-oauth2-client"></a></li>
     </ol>
   </body>
 </html>

--- a/test/ca-oauth2-client-test.html
+++ b/test/ca-oauth2-client-test.html
@@ -43,6 +43,18 @@
             done();
         });
 
+        test('ignores unknown grant types when set via property', done => {
+            caOAuth2Client.type = 'guesswork';
+            expect(caOAuth2Client.type).to.equal('password');
+            done();
+        });
+
+        test('ignores unknown grant types when set via attribute', done => {
+            caOAuth2Client.setAttribute('type', 'divination');
+            expect(caOAuth2Client.type).to.equal('password');
+            done();
+        });
+
         test('should request a token once the username and password are set', done => {
             window.fetch.withArgs('http://localhost/oauth2/authorize').returns(mockJsonResponse({
                     "access_token": "ACCESS_TOKEN",

--- a/test/ca-oauth2-client-test.html
+++ b/test/ca-oauth2-client-test.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CA OAUTH2 CLIENT | Web Lab Common UI</title>
+    <script src="/web-component-tester/browser.js"></script>
+    <script src="/bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="/bower_components/imd/imd.html">
+    <link rel="import" href="/components/ca-oauth2-client.html">
+    <link rel="import" href="/components/ca-auth.html">
+</head>
+<body>
+<test-fixture id="ca-oauth2-client">
+    <template>
+        <ca-oauth2-client href="http://localhost/oauth2/authorize" client-id="test-client" client-secret="sshhh"></ca-oauth2-client>
+    </template>
+</test-fixture>
+<script>
+    suite('<ca-oauth2-client>', () => {
+        let caOAuth2Client;
+
+        const mockJsonResponse = (body = {}, status = 200) => {
+            return Promise.resolve(new window.Response(JSON.stringify(body), {
+                status,
+                headers: { 'Content-type': 'application/json' }
+            }));
+        };
+
+        setup(done => {
+            sessionStorage.clear();
+            caOAuth2Client = fixture('ca-oauth2-client');
+            sinon.stub(window, 'fetch');
+            window.fetch.returns(Promise.reject());
+            done();
+        });
+
+        teardown(() => {
+            window.fetch.restore();
+        });
+
+        test('should default to password grant type', done => {
+            expect(caOAuth2Client.type).to.equal('password');
+            done();
+        });
+
+        test('should request a token once the username and password are set', done => {
+            window.fetch.withArgs('http://localhost/oauth2/authorize').returns(mockJsonResponse({
+                    "access_token": "ACCESS_TOKEN",
+                    "token_type": "bearer",
+                    "expires_in": 2592000,
+                    "refresh_token": "REFRESH_TOKEN",
+                    "scope": "read",
+                    "uid": 100101,
+                    "info": {"name": "Mark E. Mark", "email": "mark@thefunkybunch.com"}
+                }
+            ));
+            let eventFired = false;
+
+            caOAuth2Client.addEventListener('ca-oauth2-authorized', e => {
+                eventFired = true;
+                expect(e.detail).to.not.be.undefined;
+                expect(e.detail.access_token).to.equal('ACCESS_TOKEN');
+
+                const fetchOptions = window.fetch.getCall(0).args[1];
+                // validate that we called the authorize endpoint with an Authorization header
+                expect(fetchOptions.headers).to.not.be.undefined;
+                expect(fetchOptions.headers.get('Authorization')).to.equal(`Basic ${window.btoa('test-client:sshhh')}`);
+                // validate that we called the authorize endpoint with grant_type, username, and password
+                expect(fetchOptions.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded');
+                expect(fetchOptions.body).to.include('grant_type=password');
+                expect(fetchOptions.body).to.include('username=marky');
+                expect(fetchOptions.body).to.include('password=funky');
+                done();
+            });
+
+            caOAuth2Client.username = 'marky';
+            window.setTimeout(() => {
+                expect(eventFired).to.be.false;
+                caOAuth2Client.password = 'funky';
+            }, 100);
+        });
+
+        test('fires unauthorized event with error authorization response', done => {
+            window.fetch.withArgs('http://localhost/oauth2/authorize').returns(mockJsonResponse({ error: 'BAD_THINGS' }));
+
+            caOAuth2Client.addEventListener('ca-oauth2-authorized', () => {
+                fail();
+            });
+            caOAuth2Client.addEventListener('ca-oauth2-unauthorized', e => {
+                expect(e.detail).to.not.be.undefined;
+                expect(e.detail.message).to.equal('BAD_THINGS');
+                done();
+            });
+            caOAuth2Client.username = 'marky';
+            caOAuth2Client.password = 'funky';
+        });
+
+        test('fires unauthorized event with unauthorized authorization response', done => {
+            window.fetch.withArgs('http://localhost/oauth2/authorize').returns(mockJsonResponse({}, 401));
+
+            caOAuth2Client.addEventListener('ca-oauth2-authorized', () => {
+                fail();
+            });
+            caOAuth2Client.addEventListener('ca-oauth2-unauthorized', e => {
+                expect(e.detail).to.not.be.undefined;
+                expect(e.detail.message).to.equal('401 OK');
+                done();
+            });
+            caOAuth2Client.username = 'marky';
+            caOAuth2Client.password = 'fonky';
+        });
+
+        test('sets credentials on an ancestor ca-auth element', done => {
+            window.fetch.withArgs('http://localhost/oauth2/authorize').returns(mockJsonResponse({
+                    "access_token": "ACCESS_TOKEN"
+                }
+            ));
+
+            // Wrap the client in a ca-auth element
+            const caAuth = document.createElement('ca-auth');
+            const parent = caOAuth2Client.parentNode;
+            caAuth.appendChild(caOAuth2Client);
+            parent.appendChild(caAuth);
+            caOAuth2Client.addEventListener('ca-oauth2-authorized', e => {
+                window.setTimeout(() => {
+                    expect(caAuth.credentials).to.equal('ACCESS_TOKEN');
+                    done();
+                }, 100);
+            });
+
+            caOAuth2Client.username = 'marky';
+            caOAuth2Client.password = 'funky';
+        });
+
+        test('should be cancellable', done => {
+            window.fetch.withArgs('http://localhost/oauth2/authorize').returns(mockJsonResponse({
+                    "access_token": "ACCESS_TOKEN"
+                }
+            ));
+
+            // Wrap the client in a ca-auth element
+            const caAuth = document.createElement('ca-auth');
+            const parent = caOAuth2Client.parentNode;
+            caAuth.appendChild(caOAuth2Client);
+            parent.appendChild(caAuth);
+            caOAuth2Client.addEventListener('ca-oauth2-authorized', e => {
+                e.preventDefault();
+                window.setTimeout(() => {
+                    expect(caAuth.credentials).to.not.equal('ACCESS_TOKEN');
+                    done();
+                }, 100);
+            });
+
+            caOAuth2Client.username = 'marky';
+            caOAuth2Client.password = 'funky';
+        });
+
+    });
+    a11ySuite('ca-oauth2-client');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Requests a token and also cooperates with a container <ca-auth> to provide it as credentials.

Just does password grant for now. In the future would add e.g. implicit flow to this including handling the redirect and callback and extraction of hash parameters off the window location.