### PR TITLE
Avoid use of href for tab navigation - breaks right click - bad UX

### DIFF
--- a/components/ca-nav.html
+++ b/components/ca-nav.html
@@ -140,7 +140,8 @@ define('ca-nav', ['create-element'], (createElement) => {
                             onclick: 'javascript:void(0)',
                             'data-action': 'loadCRUD',
                             'data-rel': rel,
-                            'data-href': item.href
+                            'data-href': item.href,
+                            tabIndex: 0
                         },
                         item.title
                     );

--- a/components/ca-nav.html
+++ b/components/ca-nav.html
@@ -35,6 +35,10 @@
     ca-nav li:last-child {
         border-bottom: 0;
     }
+
+    ca-nav > nav > ul > li > a {
+        cursor: pointer;
+    }
 </style>
 <script>
 define('ca-nav', ['create-element'], (createElement) => {
@@ -132,7 +136,8 @@ define('ca-nav', ['create-element'], (createElement) => {
 
                     const link = createElement(li, 'a',
                         {
-                            href: item.href,
+                            // eslint-disable-next-line no-script-url
+                            onclick: 'javascript:void(0)',
                             'data-action': 'loadCRUD',
                             'data-rel': rel,
                             'data-href': item.href


### PR DESCRIPTION
What do people think of this approach?

Do you want a feature toggle or we could bump the version as it's a breaking change.