### PR TITLE
Allow ca-nav <li> to receive focus to support keyboard navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ jspm_packages
 
 # Optional npm cache directory
 .npm
+package-lock.json
 
 # Optional REPL history
 .node_repl_history

--- a/components/ca-nav.html
+++ b/components/ca-nav.html
@@ -140,7 +140,8 @@ define('ca-nav', ['create-element'], (createElement) => {
                             onclick: 'javascript:void(0)',
                             'data-action': 'loadCRUD',
                             'data-rel': rel,
-                            'data-href': item.href
+                            'data-href': item.href,
+                            tabIndex: 0
                         },
                         item.title
                     );


### PR DESCRIPTION
Support use of standard keyboard navigation (using tab key), ca-nav <li> elements have to have a tabIndex to allow then to receive focus.